### PR TITLE
Fix token limit display bug in CLI

### DIFF
--- a/tools/statusline-npm/README.md
+++ b/tools/statusline-npm/README.md
@@ -15,7 +15,7 @@ A custom status line for Claude Code that displays accurate token usage with a b
 - 🧱 **Brick visualization** showing token breakdown by category
 - 🔧 **Git integration**: repo:branch [commit] message | github-repo *↑↓
 - 📊 **Session metrics**: model name, lines changed, free space
-- 🎨 **Model-aware**: Automatic context limits (200k Sonnet, 1M Opus)
+- 🎨 **Model-aware**: Automatic context limits (200k for all models in Claude Code)
 - ⚡ **Zero config**: Auto-detects everything, just install and go
 
 ## 🚀 Quick Start

--- a/tools/statusline-npm/bin/cli.js
+++ b/tools/statusline-npm/bin/cli.js
@@ -53,7 +53,7 @@ ${colors.green}Features:${colors.reset}
   • Real-time context tracking from transcript files
   • Brick visualization showing token breakdown
   • Git integration (repo, branch, commit, status)
-  • Model-aware context limits (200k Sonnet, 1M Opus)
+  • Model-aware context limits (200k for all models in Claude Code)
   • Session metrics (lines changed, free space)
 
 ${colors.green}More Info:${colors.reset}

--- a/tools/statusline-npm/scripts/statusline.sh
+++ b/tools/statusline-npm/scripts/statusline.sh
@@ -101,8 +101,10 @@ transcript_path=$(echo "$input" | jq -r '.transcript_path // ""')
 model_id=$(echo "$input" | jq -r '.model.id // ""')
 
 # Determine context limit based on model
+# NOTE: While Opus 4/4.5 models have 1M context at API level, Claude Code CLI
+# enforces a 200k limit for all models. Using 200k for accurate display.
 case "$model_id" in
-    *"opus-4"*) total_tokens=1000000 ;;
+    *"opus-4"*) total_tokens=200000 ;;  # Claude Code limits to 200k
     *"sonnet-4"*|*"sonnet-3-7"*) total_tokens=200000 ;;
     *"haiku"*) total_tokens=200000 ;;
     *) total_tokens=200000 ;;  # Default

--- a/tools/statusline/README.md
+++ b/tools/statusline/README.md
@@ -9,7 +9,7 @@ A custom status line for Claude Code CLI that displays real-time context trackin
 ### Real-Time Context Tracking
 - **Accurate token usage** from Claude Code's transcript files
 - **Brick visualization** showing context breakdown by category
-- **Model-aware limits** (200k for Sonnet, 1M for Opus)
+- **Model-aware limits** (200k for all models in Claude Code)
 - **Token breakdown**: System, Tools, MCP, Memory, Messages
 
 ### Git Integration

--- a/tools/statusline/statusline.sh
+++ b/tools/statusline/statusline.sh
@@ -101,8 +101,10 @@ transcript_path=$(echo "$input" | jq -r '.transcript_path // ""')
 model_id=$(echo "$input" | jq -r '.model.id // ""')
 
 # Determine context limit based on model
+# NOTE: While Opus 4/4.5 models have 1M context at API level, Claude Code CLI
+# enforces a 200k limit for all models. Using 200k for accurate display.
 case "$model_id" in
-    *"opus-4"*) total_tokens=1000000 ;;
+    *"opus-4"*) total_tokens=200000 ;;  # Claude Code limits to 200k
     *"sonnet-4"*|*"sonnet-3-7"*) total_tokens=200000 ;;
     *"haiku"*) total_tokens=200000 ;;
     *) total_tokens=200000 ;;  # Default


### PR DESCRIPTION
While Opus 4/4.5 models have 1M token context at API level, Claude Code CLI enforces a 200k limit for all models. This caused the status line to incorrectly display "106k/1000k tokens" when using Opus, making the progress bar and percentage calculations misleading.

- Update statusline.sh to use 200k for opus-4* models
- Add clarifying comments about Claude Code limits
- Update README and CLI help text to reflect accurate limits