### PR TITLE
feat(scripts): Add fork-friendly author configuration for plugin manifests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,14 @@
+# Plugin manifest author configuration
+# Copy this file to .env and update for your fork
+
+# Your fork's author info (used only for skills you own)
+PLUGIN_AUTHOR_NAME="Your Name"
+PLUGIN_AUTHOR_EMAIL="your@email.com"
+PLUGIN_REPOSITORY="https://github.com/your-org/claude-skills"
+
+# Skills owned by this fork (comma-separated, no spaces)
+# Only these skills will use your author info above.
+# All other skills preserve original upstream author (Jeremy Dawes/jezweb).
+#
+# Example: SKILL_PATHS=my-skill,another-skill,admin-custom
+SKILL_PATHS=

--- a/scripts/generate-plugin-manifests.sh
+++ b/scripts/generate-plugin-manifests.sh
@@ -6,8 +6,40 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$(cd "$SCRIPT_DIR/../skills" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load author config from .env if it exists
+if [ -f "$ROOT_DIR/.env" ]; then
+  source "$ROOT_DIR/.env"
+fi
+
+# Original upstream author (preserved for skills not owned by fork)
+UPSTREAM_AUTHOR_NAME="Jeremy Dawes"
+UPSTREAM_AUTHOR_EMAIL="jeremy@jezweb.net"
+UPSTREAM_REPOSITORY="https://github.com/jezweb/claude-skills"
+
+# Fork author (used only for skills listed in SKILL_PATHS)
+FORK_AUTHOR_NAME="${PLUGIN_AUTHOR_NAME:-$UPSTREAM_AUTHOR_NAME}"
+FORK_AUTHOR_EMAIL="${PLUGIN_AUTHOR_EMAIL:-$UPSTREAM_AUTHOR_EMAIL}"
+FORK_REPOSITORY="${PLUGIN_REPOSITORY:-$UPSTREAM_REPOSITORY}"
+
+# Skills owned by this fork (comma-separated in .env)
+# Only these skills will use FORK_AUTHOR_* values
+FORK_SKILL_PATHS="${SKILL_PATHS:-}"
+
+# Helper function to check if skill is owned by fork
+is_fork_skill() {
+  local skill="$1"
+  if [ -z "$FORK_SKILL_PATHS" ]; then
+    return 1  # No fork skills defined, all use upstream
+  fi
+  echo ",$FORK_SKILL_PATHS," | grep -q ",$skill,"
+}
 
 echo "Generating plugin.json files for all skills..."
+if [ -n "$FORK_SKILL_PATHS" ]; then
+  echo "Fork skills (custom author): $FORK_SKILL_PATHS"
+fi
 echo "Skills directory: $SKILLS_DIR"
 echo ""
 
@@ -91,57 +123,145 @@ for skill_dir in "$SKILLS_DIR"/*; do
   description=$(echo "$description" | sed 's/Keywords:.*$//' | tr -d '"' | tr -d "'" | sed 's/  */ /g' | sed 's/^ *//;s/ *$//' | head -c 500)
 
   # Detect agents in skill's agents/ directory
-  # Per Claude Code plugin spec: agents field should be directory path, not array of names
+  # Claude Code expects agents as an array of objects with name, description, and source
   agents_json=""
   agents_dir="$skill_dir/agents"
   if [ -d "$agents_dir" ]; then
-    agent_count=$(find "$agents_dir" -maxdepth 1 -name "*.md" -type f 2>/dev/null | wc -l)
+    agent_files=$(find "$agents_dir" -maxdepth 1 -name "*.md" -type f 2>/dev/null | sort)
+    agent_count=$(echo "$agent_files" | grep -c . 2>/dev/null || echo 0)
     if [ "$agent_count" -gt 0 ]; then
-      agents_json="\"./agents/\""
-      agent_names=$(find "$agents_dir" -maxdepth 1 -name "*.md" -type f -exec basename {} .md \; | sort | tr '\n' ' ')
-      echo "  📦 Found $agent_count agent(s): $agent_names"
+      agents_json="["
+      first_agent=true
+      for agent_file in $agent_files; do
+        agent_basename=$(basename "$agent_file" .md)
+        # Extract agent name and description from frontmatter
+        agent_name=$(awk '/^---$/,/^---$/{if(/^name:/) {gsub(/^name: */, ""); print; exit}}' "$agent_file")
+        if [ -z "$agent_name" ]; then
+          agent_name="$agent_basename"
+        fi
+        agent_desc=$(awk '/^---$/,/^---$/{if(/^description:/ && $0 !~ /[\|>]$/){gsub(/^description: */, ""); print; exit}}' "$agent_file")
+        if [ -z "$agent_desc" ]; then
+          # Try multi-line description
+          agent_desc=$(awk '
+            /^description: [\|>]/{flag=1; next}
+            /^[a-z-]+:/{flag=0}
+            flag && /^  /{gsub(/^  /, ""); line=line $0 " "}
+            END{gsub(/ $/, "", line); print line}
+          ' "$agent_file" | head -c 300)
+        fi
+        if [ -z "$agent_desc" ]; then
+          agent_desc="Agent for $agent_name"
+        fi
+        # Clean description (remove quotes, limit length)
+        agent_desc=$(echo "$agent_desc" | tr -d '"' | tr -d "'" | sed 's/  */ /g' | sed 's/^ *//;s/ *$//' | head -c 300)
+
+        if [ "$first_agent" = true ]; then
+          first_agent=false
+        else
+          agents_json="$agents_json,"
+        fi
+        agents_json="$agents_json
+    {
+      \"name\": \"$agent_name\",
+      \"description\": \"$agent_desc\",
+      \"source\": \"./agents/$agent_basename.md\"
+    }"
+      done
+      agents_json="$agents_json
+  ]"
+      echo "  📦 Found $agent_count agent(s): $(echo "$agent_files" | xargs -I {} basename {} .md | tr '\n' ' ')"
     fi
   fi
 
   # Detect commands in skill's commands/ directory
-  # Per Claude Code plugin spec: commands field should be directory path
+  # Claude Code expects commands as an array of objects with name, description, and source
   commands_json=""
   commands_dir="$skill_dir/commands"
   if [ -d "$commands_dir" ]; then
-    command_count=$(find "$commands_dir" -maxdepth 1 -name "*.md" -type f 2>/dev/null | wc -l)
+    command_files=$(find "$commands_dir" -maxdepth 1 -name "*.md" -type f 2>/dev/null | sort)
+    command_count=$(echo "$command_files" | grep -c . 2>/dev/null || echo 0)
     if [ "$command_count" -gt 0 ]; then
-      commands_json="\"./commands/\""
-      command_names=$(find "$commands_dir" -maxdepth 1 -name "*.md" -type f -exec basename {} .md \; | sort | tr '\n' ' ')
-      echo "  📜 Found $command_count command(s): $command_names"
+      commands_json="["
+      first_command=true
+      for command_file in $command_files; do
+        command_basename=$(basename "$command_file" .md)
+        # Extract command name and description from frontmatter
+        command_name=$(awk '/^---$/,/^---$/{if(/^name:/) {gsub(/^name: */, ""); print; exit}}' "$command_file")
+        if [ -z "$command_name" ]; then
+          command_name="$command_basename"
+        fi
+        command_desc=$(awk '/^---$/,/^---$/{if(/^description:/ && $0 !~ /[\|>]$/){gsub(/^description: */, ""); print; exit}}' "$command_file")
+        if [ -z "$command_desc" ]; then
+          # Try multi-line description
+          command_desc=$(awk '
+            /^description: [\|>]/{flag=1; next}
+            /^[a-z-]+:/{flag=0}
+            flag && /^  /{gsub(/^  /, ""); line=line $0 " "}
+            END{gsub(/ $/, "", line); print line}
+          ' "$command_file" | head -c 300)
+        fi
+        if [ -z "$command_desc" ]; then
+          command_desc="Command for $command_name"
+        fi
+        # Clean description (remove quotes, limit length)
+        command_desc=$(echo "$command_desc" | tr -d '"' | tr -d "'" | sed 's/  */ /g' | sed 's/^ *//;s/ *$//' | head -c 300)
+
+        if [ "$first_command" = true ]; then
+          first_command=false
+        else
+          commands_json="$commands_json,"
+        fi
+        commands_json="$commands_json
+    {
+      \"name\": \"$command_name\",
+      \"description\": \"$command_desc\",
+      \"source\": \"./commands/$command_basename.md\"
+    }"
+      done
+      commands_json="$commands_json
+  ]"
+      echo "  📜 Found $command_count command(s): $(echo "$command_files" | xargs -I {} basename {} .md | tr '\n' ' ')"
     fi
   fi
 
   # Generate plugin.json
-  # Build optional fields
-  agents_line=""
-  if [ -n "$agents_json" ]; then
-    agents_line=",
-  \"agents\": $agents_json"
+  # Note: commands/ and agents/ directories are auto-discovered by Claude Code
+  # Do NOT add explicit commands or agents fields - they cause validation errors
+
+  # Read version from VERSION file if it exists, otherwise default to 1.0.0
+  version_file="$skill_dir/VERSION"
+  if [ -f "$version_file" ]; then
+    skill_version=$(cat "$version_file" | tr -d '[:space:]')
+  else
+    skill_version="1.0.0"
   fi
 
-  commands_line=""
-  if [ -n "$commands_json" ]; then
-    commands_line=",
-  \"commands\": $commands_json"
+  # Determine author info based on whether this is a fork skill
+  if is_fork_skill "$skill_name"; then
+    # Fork skill - use custom author info
+    author_name="$FORK_AUTHOR_NAME"
+    author_email="$FORK_AUTHOR_EMAIL"
+    repository="$FORK_REPOSITORY"
+    echo "  👤 Using fork author: $author_name"
+  else
+    # Upstream skill - always use upstream author
+    author_name="$UPSTREAM_AUTHOR_NAME"
+    author_email="$UPSTREAM_AUTHOR_EMAIL"
+    repository="$UPSTREAM_REPOSITORY"
   fi
 
   cat > "$plugin_json" << EOF
 {
   "name": "$skill_name",
   "description": "$description",
-  "version": "1.0.0",
+  "version": "$skill_version",
   "author": {
-    "name": "Jeremy Dawes",
-    "email": "jeremy@jezweb.net"
+    "name": "$author_name",
+    "email": "$author_email"
   },
   "license": "MIT",
-  "repository": "https://github.com/jezweb/claude-skills",
-  "keywords": $keywords_json$commands_line$agents_line
+  "repository": "$repository",
+  "keywords": $keywords_json
 }
 EOF
 
@@ -151,7 +271,12 @@ done
 echo ""
 echo "✅ Done! Generated plugin.json for $count skills"
 echo ""
+
+# Extract marketplace name from resolved repository URL (uses FORK_REPOSITORY which falls back to UPSTREAM_REPOSITORY)
+MARKETPLACE_NAME=$(echo "$FORK_REPOSITORY" | sed 's|.*/||' | sed 's|\.git$||')
+MARKETPLACE_ORG=$(echo "$FORK_REPOSITORY" | sed 's|https://github.com/||' | sed 's|/.*||')
+
 echo "Next steps:"
 echo "1. Review generated files: find skills/ -name plugin.json"
-echo "2. Test marketplace: /plugin marketplace add https://github.com/jezweb/claude-skills"
-echo "3. Install a skill: /plugin install cloudflare-worker-base@jezweb-skills"
+echo "2. Test marketplace: /plugin marketplace add $FORK_REPOSITORY"
+echo "3. Install a skill: /plugin install cloudflare-worker-base@${MARKETPLACE_ORG}-${MARKETPLACE_NAME}"


### PR DESCRIPTION
## Summary

Enable forks to maintain proper attribution when generating plugin.json files:

- **Add `.env.sample` template** for fork configuration with `PLUGIN_AUTHOR_NAME`, `PLUGIN_AUTHOR_EMAIL`, `PLUGIN_REPOSITORY`
- **Support `SKILL_PATHS`** to specify which skills are owned by the fork (comma-separated)
- **Preserve upstream author** (Jeremy Dawes) for skills not listed in `SKILL_PATHS`
- **Add per-skill `VERSION` file support** for independent versioning
- **Fix plugin.json generation** - remove explicit `commands`/`agents` fields (they cause validation errors; Claude Code auto-discovers these directories)
- **Dynamic "Next steps" output** uses fork's repository URL

## Why This Matters

When someone forks this repo to add their own skills, they need a way to:
1. Properly attribute their new skills to themselves
2. Keep original authorship intact for upstream skills
3. Avoid editing the script directly (which creates merge conflicts)

## Example Usage

```bash
# Copy template
cp .env.sample .env

# Configure for your fork
PLUGIN_AUTHOR_NAME="Your Name"
PLUGIN_AUTHOR_EMAIL="you@example.com"
PLUGIN_REPOSITORY="https://github.com/your-org/claude-skills"
SKILL_PATHS=my-new-skill,another-skill

# Generate manifests - your skills get your info, upstream skills keep original author
./scripts/generate-plugin-manifests.sh
```

## Test plan

- [ ] Verify `.env.sample` is not loaded (only `.env`)
- [ ] Test with no `.env` file (should use upstream defaults)
- [ ] Test with `.env` but empty `SKILL_PATHS` (all skills use upstream author)
- [ ] Test with specific `SKILL_PATHS` (only listed skills get fork author)
- [ ] Verify generated `plugin.json` files are valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)