### PR TITLE
dev-tools: genericise Basalt Cortex references in public skills

### DIFF
--- a/plugins/dev-tools/skills/deep-research/SKILL.md
+++ b/plugins/dev-tools/skills/deep-research/SKILL.md
@@ -52,9 +52,7 @@ For each related project found:
 - Check for reusable code (schemas, components, utilities, configs)
 - Note what worked well and what didn't (from git history, TODO comments)
 
-Also check:
-- Basalt Cortex (`~/Documents/basalt-cortex/`) for related clients, contacts, knowledge facts
-- `grep -rl "KEYWORD" ~/Documents/basalt-cortex/ --include="*.md"`
+Also check any personal knowledge store you maintain — Obsidian vault, `~/Documents/notes/`, a private repo of markdown files. `grep -rl "KEYWORD" <path> --include="*.md"` across it often surfaces client names, contacts, decisions you forgot you'd captured.
 
 ### 3. Web Research
 
@@ -157,7 +155,7 @@ Research the building blocks — what already exists that you can use or learn f
 
 ### 7. Platform Capability Deep-Dive (wide + deep)
 
-**This is critical.** Claude's training data is always behind on platform features. Cloudflare, Vercel, Firebase, Supabase — they all ship new capabilities constantly. A feature you assume doesn't exist might have launched last month. The Basalt Cortex project exists because of capabilities (Workers AI toMarkdown, Vectorize metadata filtering, D1 FTS5) that weren't obvious without actively looking.
+**This is critical.** Claude's training data is always behind on platform features. Cloudflare, Vercel, Firebase, Supabase — they all ship new capabilities constantly. A feature you assume doesn't exist might have launched last month. Whole projects have been unlocked by capabilities (Workers AI `toMarkdown`, Vectorize metadata filtering, D1 FTS5, etc.) that weren't obvious without actively looking.
 
 **Do NOT rely on training data for platform capabilities.** Go read the actual current docs.
 

--- a/plugins/dev-tools/skills/team-update/SKILL.md
+++ b/plugins/dev-tools/skills/team-update/SKILL.md
@@ -47,7 +47,7 @@ Check for each capability category:
 | **Git** | `git rev-parse --is-inside-work-tree` | Skip commit summaries |
 | **Issues** | MCP tools matching `github`, `linear`, `jira` | Skip or output text list |
 | **Tasks** | MCP tools matching `tasks`, `todos`, `asana` | Skip or output text list |
-| **Knowledge** | Basalt Cortex (`~/Documents/basalt-cortex/`) | Search for related knowledge notes |
+| **Knowledge** | Personal knowledge vault if you keep one (Obsidian, `~/Documents/notes/`, etc.) | Search for related knowledge notes |
 
 ### User Preferences (Ask)
 

--- a/plugins/dev-tools/skills/team-update/references/discovery-patterns.md
+++ b/plugins/dev-tools/skills/team-update/references/discovery-patterns.md
@@ -55,9 +55,9 @@ If true, git is available. Capture the repo name from the directory or `git remo
 
 | Source | Location | Notes |
 |---|---|---|
-| Basalt Cortex | `~/Documents/basalt-cortex/` | Clients, contacts, knowledge — grep to search |
+| Personal knowledge vault | Obsidian, `~/Documents/notes/`, or any local markdown folder | Clients, contacts, knowledge — grep to search |
 
-**What to capture**: Whether Basalt Cortex vault exists and has relevant data.
+**What to capture**: Whether a personal knowledge vault exists and has relevant data.
 
 ## Discovery Output
 


### PR DESCRIPTION
## Summary

Two public skills in `plugins/dev-tools/` hardcoded `~/Documents/basalt-cortex/` as a knowledge-vault location. This leaked internal Jezweb setup into a skill used by external contributors — most users don't have that directory. Basalt Cortex is also now retired internally (shared-knowledge role moved to `.jez/knowledge/` per 2026-04-22 team decision; private mining plugin removed from team-skills in `07eafb0`).

Reworded to generic "personal knowledge vault if you keep one" framing across three files.

## Changes

- **`plugins/dev-tools/skills/deep-research/SKILL.md`** (Step 2): swap "Basalt Cortex" bullet for generic "personal knowledge store (Obsidian vault, `~/Documents/notes/`, a private repo of markdown files)". Keep the useful `grep -rl KEYWORD` pattern.
- **`plugins/dev-tools/skills/deep-research/SKILL.md`** (Step 7): drop "Basalt Cortex project" proper noun from the Cloudflare-capabilities anecdote; keep the substantive "Workers AI `toMarkdown`, Vectorize metadata filtering, D1 FTS5" examples. The point about Claude training data being behind on platform features lands without needing the internal project reference.
- **`plugins/dev-tools/skills/team-update/SKILL.md`** (Knowledge row): generic personal-vault pattern instead of hardcoded Basalt Cortex.
- **`plugins/dev-tools/skills/team-update/references/discovery-patterns.md`**: same two-location cleanup (table row + "what to capture" bullet).

## Test plan

- [x] All three files edited, no syntactic breakage in markdown
- [x] grep confirms no remaining "basalt" or "cortex" references in `plugins/dev-tools/`
- [ ] Skills still read coherently without the proper-noun anchor

## Context

Raised per Jez greenlight in Dev Chat (msg `nP6g6buoQSY`) following my flag yesterday about three stale public-facing Cortex refs. Sister commit in team-skills was `07eafb0` (removed the basalt plugin entirely). A further `audit-fix.py` stale-ref cleanup exists in `.jez/scripts/` but is internal tooling and scoped for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)