### PR TITLE
fix(brains-trust): move Claude Code frontmatter extensions to metadata block (agentskills.io spec compliance)

### DIFF
--- a/plugins/dev-tools/skills/brains-trust/SKILL.md
+++ b/plugins/dev-tools/skills/brains-trust/SKILL.md
@@ -5,20 +5,21 @@ description: >
   Queries models via OpenRouter, Gemini, or OpenAI APIs. Supports single opinion, multi-model consensus,
   and devil's advocate patterns. Trigger with 'brains trust', 'second opinion', 'ask gemini', 'ask gpt',
   'peer review', 'consult', 'challenge this', or 'devil's advocate'.
-triggers:
-  - brains trust
-  - second opinion
-  - ask gemini
-  - ask gpt
-  - peer review
-  - consult
-  - challenge this
-  - devil's advocate
-  - what does gemini think
-  - what does gpt think
-user-invocable: true
-argument-hint: "[question or topic]"
 compatibility: claude-code-only
+metadata:
+  user-invocable: "true"
+  argument-hint: "[question or topic]"
+  triggers:
+    - brains trust
+    - second opinion
+    - ask gemini
+    - ask gpt
+    - peer review
+    - consult
+    - challenge this
+    - devil's advocate
+    - what does gemini think
+    - what does gpt think
 ---
 
 # Brains Trust


### PR DESCRIPTION
## Problem

`brains-trust/SKILL.md` fails agentskills.io spec validation. Running `npx skills-ref validate` against all skills in this repo:

```
Results: 42 passed, 1 failed
Failures:
  plugins/dev-tools/skills/brains-trust:
    Unexpected fields in frontmatter: argument-hint, triggers, user-invocable.
    Only allowed-tools, compatibility, description, license, metadata, name are allowed.
```

These three fields (`argument-hint`, `triggers`, `user-invocable`) are Claude-Code-specific extensions used for slash-command UX. Per the [agentskills.io specification](https://agentskills.io/specification), only `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools` are valid at the top level. The spec explicitly allows `metadata:` as an arbitrary key/value mapping for "additional metadata not defined by the Agent Skills spec" — which is exactly the right home for Claude-Code-specific extensions.

## Change

Moves the 3 non-spec fields under `metadata:`. The spec says:

> `metadata`: Arbitrary key-value mapping for additional metadata.
> Clients can use this to store additional properties not defined by the Agent Skills spec.
> We recommend making your key names reasonably unique to avoid accidental conflicts.

Diff shape:

```yaml
# Before
---
name: brains-trust
description: >
  ...
triggers:
  - brains trust
  - ...
user-invocable: true
argument-hint: "[question or topic]"
compatibility: claude-code-only
---

# After
---
name: brains-trust
description: >
  ...
compatibility: claude-code-only
metadata:
  user-invocable: "true"
  argument-hint: "[question or topic]"
  triggers:
    - brains trust
    - ...
---
```

Zero content change. Same data, spec-compliant location.

## Verification

Post-fix validator output:

```
$ npx skills-ref@0.1.5 validate plugins/dev-tools/skills/brains-trust
Valid skill: plugins/dev-tools/skills/brains-trust
```

Whole-repo validation goes from 85/87 → 86/87 passing with this + companion PR on jez-skills (create-l2chat-agent, same fix shape).

## Risk — please verify before merge

**Does Claude Code still invoke `/brains-trust` correctly after this change?**

Claude Code may read `triggers` / `user-invocable` / `argument-hint` from top-level for:
- Slash-command registration (`user-invocable: true`)
- Natural-language trigger matching (`triggers:` list)
- Arg-completion UI hint (`argument-hint:`)

If Claude Code reads these **specifically from top-level** and doesn't look under `metadata:`, this change regresses the skill's UX.

**How to test**: after merge, in a Claude Code session:
1. Type `/brains-trust` — does autocomplete show it?
2. Type `/brains-trust foo bar` — does it invoke?
3. Try natural-language trigger: say "brains trust" in a message — does it suggest the skill?

If any of those break, revert this PR with `git revert <commit>`. I'll then refile keeping the 3 fields at top-level and accept that these 2 skills (brains-trust + create-l2chat-agent) are genuinely Claude-Code-only extensions that shouldn't pretend to be spec-compliant. The validator failing on those 2 is correct signal, not a bug.

## Related

- Companion PR on `jezweb/jez-skills` for `create-l2chat-agent` (same fix shape)
- Discussion in `marcus/specialists/skills/discoveries.md` 2026-04-24 under the agentskills.io ecosystem finding
- Broader spec-compliance audit: 85 of 87 skills pass today; these 2 are the full failure list