### PR TITLE
ci: add skills-ref validate (agentskills.io spec) alongside skill-lint

### DIFF
--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -31,3 +31,12 @@ jobs:
       - name: Run skill-lint
         if: steps.changed.outputs.skip != 'true'
         run: ./bin/skill-lint ${{ steps.changed.outputs.dirs }}
+
+      - name: Run skills-ref validate (agentskills.io spec)
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          DIRS: ${{ steps.changed.outputs.dirs }}
+        run: |
+          for dir in $DIRS; do
+            npx -y skills-ref@0.1.5 validate "$dir"
+          done


### PR DESCRIPTION
## Change

Adds a second step to the existing `Lint skills` workflow that runs the official agentskills.io validator (`skills-ref`) against changed SKILL.md directories.

```yaml
- name: Run skills-ref validate (agentskills.io spec)
  if: steps.changed.outputs.skip != 'true'
  env:
    DIRS: ${{ steps.changed.outputs.dirs }}
  run: |
    for dir in $DIRS; do
      npx -y skills-ref@0.1.5 validate "$dir"
    done
```

## Why

Complementary to the existing `bin/skill-lint`:

| Checker | Enforces |
|---------|----------|
| `bin/skill-lint` | Our internal style (500-line cap, `bin/` executable conventions, etc.) |
| `skills-ref` | The [agentskills.io open-standard spec](https://agentskills.io/specification) — frontmatter fields, `name`/`description` constraints, allowed optional fields |

Together they give every PR two orthogonal quality signals.

## Why skills-ref specifically

`skills-ref` is the official reference validator from [agentskills.io](https://agentskills.io) (Anthropic-originated, ~35 adopting tools including Cursor, VS Code Copilot, OpenAI Codex, Gemini CLI, OpenHands, Goose, Letta). Running it in CI signals "these skills are portable across compliant agents, not just Claude Code-specific."

Current state: **41 of 42 skills in this repo pass spec validation on main** (ran locally 2026-04-24). The one failure is `brains-trust`, fixed in [#77](https://github.com/jezweb/claude-skills/pull/77).

## Security note

Uses `env:` + `$DIRS` pattern instead of inline `${{ }}` interpolation in `run:` — follows GitHub's [command-injection hardening guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/) since `$DIRS` is derived from `git diff --name-only` output (attacker-controlled file paths in a malicious PR could otherwise inject shell commands).

The existing `skill-lint` step above uses the direct-interpolation pattern and has the same theoretical risk — out of scope for this PR but worth hardening separately.

## Ordering consideration

**Depends on #77 merging first** to keep main green. If a PR touches `brains-trust` before #77 merges, this CI step will correctly fail validation. After #77 merges, standard PRs that don't touch the 2 Claude-Code-extension skills pass cleanly.

## Test plan

- [ ] Merge #77 (brains-trust fix)
- [ ] Merge jez-skills#12 companion (not required for this repo's CI)
- [ ] Merge this PR
- [ ] Verify next PR touching any SKILL.md runs both steps green