### PR TITLE
positioning: align with agentskills.io ecosystem (README + compatibility sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Claude Code Skills
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![agentskills.io compatible](https://img.shields.io/badge/agentskills.io-compatible-success)](https://agentskills.io)
 
-Production workflow skills for [Claude Code](https://claude.com/claude-code). Each skill guides Claude through a recipe to produce tangible output — scaffolded projects, generated assets, professional documents, deployed services.
+Production workflow skills for [Claude Code](https://claude.com/claude-code). Each skill guides an agent through a recipe to produce tangible output — scaffolded projects, generated assets, professional documents, deployed services.
 
 10 plugins. 60 skills. Every one produces something.
+
+## Compatibility
+
+These skills follow the [agentskills.io](https://agentskills.io) open standard (originally developed by Anthropic, now maintained as an open spec). Built and tested primarily for [Claude Code](https://claude.com/claude-code), they also load in any compatible agent runtime — the ecosystem currently includes Cursor, VS Code Copilot, OpenAI Codex, Gemini CLI, OpenHands, Goose, Letta, and ~30 others. Install mechanics differ per tool; the skill content is portable.
+
+Spec validation runs in CI via [`skills-ref`](https://github.com/agentskills/agentskills/tree/main/skills-ref) alongside our internal `bin/skill-lint`.
 
 ## Quick Start
 

--- a/plugins/cloudflare/skills/cloudflare-api/SKILL.md
+++ b/plugins/cloudflare/skills/cloudflare-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudflare-api
 description: "Hit the Cloudflare REST API directly for operations that wrangler and MCP can't handle well. Bulk DNS, custom hostnames, email routing, cache purge, WAF rules, redirect rules, zone settings, Worker routes, D1 cross-database queries, R2 bulk operations, KV bulk read/write, Vectorize queries, Queues, and fleet-wide resource audits. Produces curl commands or scripts. Triggers: 'cloudflare api', 'bulk dns', 'custom hostname', 'email routing', 'cache purge', 'waf rule', 'd1 query', 'r2 bucket', 'kv bulk', 'vectorize query', 'audit resources', 'fleet operation'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools:
   - Read
   - Write

--- a/plugins/cloudflare/skills/cloudflare-worker-builder/SKILL.md
+++ b/plugins/cloudflare/skills/cloudflare-worker-builder/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Workflow: describe project, scaffold structure, configure bindings, deploy.
   Use when creating Workers projects, setting up Hono/Vite, configuring D1/R2/KV bindings,
   or troubleshooting export syntax errors, API route conflicts, HMR issues, or deployment failures.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Cloudflare Worker Builder

--- a/plugins/cloudflare/skills/d1-drizzle-schema/SKILL.md
+++ b/plugins/cloudflare/skills/d1-drizzle-schema/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: d1-drizzle-schema
 description: "Generate Drizzle ORM schemas for Cloudflare D1 databases with correct D1-specific patterns. Produces schema files, migration commands, type exports, and DATABASE_SCHEMA.md documentation. Handles D1 quirks: foreign keys always enforced, no native BOOLEAN/DATETIME types, 100 bound parameter limit, JSON stored as TEXT. Use when creating a new database, adding tables, or scaffolding a D1 data layer."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # D1 Drizzle Schema

--- a/plugins/cloudflare/skills/d1-migration/SKILL.md
+++ b/plugins/cloudflare/skills/d1-migration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: d1-migration
 description: "Cloudflare D1 migration workflow: generate with Drizzle, inspect SQL for gotchas, apply to local and remote, fix stuck migrations, handle partial failures. Use when running migrations, fixing migration errors, or setting up D1 schemas."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # D1 Migration Workflow

--- a/plugins/cloudflare/skills/db-seed/SKILL.md
+++ b/plugins/cloudflare/skills/db-seed/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Glob
   - Grep
   - Bash
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Database Seed Generator

--- a/plugins/cloudflare/skills/hono-api-scaffolder/SKILL.md
+++ b/plugins/cloudflare/skills/hono-api-scaffolder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hono-api-scaffolder
 description: "Scaffold Hono API routes for Cloudflare Workers. Produces route files, middleware, typed bindings, Zod validation, error handling, and API_ENDPOINTS.md documentation. Use after a project is set up with cloudflare-worker-builder or vite-flare-starter, when you need to add API routes, create endpoints, or generate API documentation."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Hono API Scaffolder

--- a/plugins/cloudflare/skills/tanstack-start/SKILL.md
+++ b/plugins/cloudflare/skills/tanstack-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tanstack-start
 description: "Build a full-stack TanStack Start app on Cloudflare Workers from scratch — SSR, file-based routing, server functions, D1+Drizzle, better-auth, Tailwind v4+shadcn/ui. No template repo — Claude generates every file fresh per project."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # TanStack Start on Cloudflare

--- a/plugins/cloudflare/skills/vite-flare-starter/SKILL.md
+++ b/plugins/cloudflare/skills/vite-flare-starter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vite-flare-starter
 description: "Scaffold a full-stack Cloudflare app from vite-flare-starter — React 19, Hono, D1+Drizzle, better-auth, Tailwind v4+shadcn/ui, TanStack Query, R2, Workers AI. Run setup.sh to clone, configure, and deploy."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Vite Flare Starter

--- a/plugins/design-assets/skills/ai-image-generator/SKILL.md
+++ b/plugins/design-assets/skills/ai-image-generator/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # AI Image Generator

--- a/plugins/design-assets/skills/color-palette/SKILL.md
+++ b/plugins/design-assets/skills/color-palette/SKILL.md
@@ -6,7 +6,7 @@ description: >
   and Tailwind v4 CSS output. Includes WCAG contrast checking.
   Use when setting up design systems, creating Tailwind themes, building brand
   colours from a hex value, or checking colour accessibility.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Colour Palette Generator

--- a/plugins/design-assets/skills/favicon-gen/SKILL.md
+++ b/plugins/design-assets/skills/favicon-gen/SKILL.md
@@ -6,7 +6,7 @@ description: >
   manifest. Use when initialising websites, replacing CMS default favicons, converting
   logos to favicons, creating branded icons from initials, or troubleshooting favicon
   not displaying, iOS black square, or missing manifest.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Favicon Generator

--- a/plugins/design-assets/skills/icon-set-generator/SKILL.md
+++ b/plugins/design-assets/skills/icon-set-generator/SKILL.md
@@ -10,7 +10,7 @@ description: >
   "I need icons", "website icons", "project icons", or any request for consistent visual
   assets for a web project. This skill produces individual SVG files with a consistent
   style engine, not generic icon library lookups.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Icon Set Generator

--- a/plugins/design-assets/skills/image-processing/SKILL.md
+++ b/plugins/design-assets/skills/image-processing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: image-processing
 description: "Process images for web development — resize, crop, trim whitespace, convert formats (PNG/WebP/JPG), optimise file size, generate thumbnails, create OG card images. Uses Pillow (Python) — no ImageMagick needed. Trigger with 'resize image', 'convert to webp', 'trim logo', 'optimise images', 'make thumbnail', 'create OG image', 'crop whitespace', 'process image', or 'image too large'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Image Processing

--- a/plugins/dev-tools/skills/app-docs/SKILL.md
+++ b/plugins/dev-tools/skills/app-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: app-docs
 description: "Generate complete user documentation for a web app with screenshots. Browses the app via browser automation, screenshots every screen, and produces a structured user guide with step-by-step instructions, annotated screenshots, workflow diagrams, and reference tables. Supports quick (key screens), standard (all pages), thorough (every state and flow), and exhaustive (publishable documentation suite). Triggers: 'document the app', 'user guide', 'app documentation', 'screenshot docs', 'generate user docs', 'help docs', 'how-to guide', 'write the docs'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # App Documentation Generator

--- a/plugins/dev-tools/skills/brains-trust/SKILL.md
+++ b/plugins/dev-tools/skills/brains-trust/SKILL.md
@@ -18,7 +18,7 @@ triggers:
   - what does gpt think
 user-invocable: true
 argument-hint: "[question or topic]"
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Brains Trust

--- a/plugins/dev-tools/skills/deep-research/SKILL.md
+++ b/plugins/dev-tools/skills/deep-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deep-research
 description: "Deep research and discovery before building something new. Explores local projects for reusable code, researches competitors, reads forums and reviews, analyses plugin ecosystems, investigates technical options, and produces a comprehensive research brief. Three depths: focused (30 min), wide (1-2 hours), deep (3-6 hours). Triggers: 'research this', 'deep research', 'discovery', 'explore the space', 'what should I build', 'competitive analysis', 'before I start building', 'research before coding'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Deep Research

--- a/plugins/dev-tools/skills/fork-discipline/SKILL.md
+++ b/plugins/dev-tools/skills/fork-discipline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fork-discipline
 description: "Audit and enforce the core/client boundary in multi-client projects. Detects where shared platform code is tangled with client-specific code, finds hardcoded client checks, config files that replace instead of merge, scattered client code, migration conflicts, and missing extension points. Produces a boundary map, violation report, and refactoring plan. Optionally generates FORK.md documentation and restructuring scripts. Triggers: 'fork discipline', 'check the boundary', 'is this core or client', 'platform audit', 'client separation', 'fork test', 'refactor for multi-client', 'clean up the fork'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools:
   - Read
   - Write

--- a/plugins/dev-tools/skills/git-workflow/SKILL.md
+++ b/plugins/dev-tools/skills/git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-workflow
 description: "Guided git workflows: prepare PRs, clean up branches, resolve merge conflicts, handle monorepo tags, squash-and-merge patterns. Use when asked to prepare a PR, clean branches, resolve conflicts, or tag a release."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Git Workflow

--- a/plugins/dev-tools/skills/github-release/SKILL.md
+++ b/plugins/dev-tools/skills/github-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-release
 description: "Prepare and publish GitHub releases. Sanitizes code for public release (secrets scan, personal artifacts, LICENSE/README validation), creates version tags, and publishes via gh CLI. Trigger with 'release', 'publish', 'open source', 'prepare for release', 'create release', or 'github release'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # GitHub Release

--- a/plugins/dev-tools/skills/onboarding-ux/SKILL.md
+++ b/plugins/dev-tools/skills/onboarding-ux/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: onboarding-ux
 description: "Audit and generate in-app user guidance — onboarding flows, empty states, tooltips, feature tours, contextual help, defaults, and inline hints. Browses the app to find where new users would get stuck, then produces the actual content and code to fix it. Pairs with ux-audit: audit finds problems, this skill builds the solutions. Triggers: 'onboarding', 'help content', 'empty states', 'user guidance', 'first run experience', 'feature tour', 'app is confusing', 'new user experience', 'make the app welcoming'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Onboarding UX

--- a/plugins/dev-tools/skills/project-docs/SKILL.md
+++ b/plugins/dev-tools/skills/project-docs/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Glob
   - Grep
   - Bash
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Project Documentation Generator

--- a/plugins/dev-tools/skills/project-health/SKILL.md
+++ b/plugins/dev-tools/skills/project-health/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-health
 description: "All-in-one project configuration and health management. Sets up new projects (settings.local.json, CLAUDE.md, .gitignore), audits existing projects (permissions, context quality, MCP coverage, leaked secrets, stale docs), tidies accumulated cruft, captures session learnings, and adds permission presets. Uses sub-agents for heavy analysis to keep main context clean. Trigger with 'project health', 'check project', 'setup project', 'kickoff', 'bootstrap', 'tidy permissions', 'clean settings', 'capture learnings', 'audit context', 'add python permissions', or 'init project'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Project Health

--- a/plugins/dev-tools/skills/responsiveness-check/SKILL.md
+++ b/plugins/dev-tools/skills/responsiveness-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: responsiveness-check
 description: "Test website responsiveness across viewport widths using browser automation. Resizes a single session through breakpoints, screenshots each width, and detects layout transitions (column changes, nav switches, overflow). Produces comparison reports showing exactly where layouts break. Trigger with 'responsiveness check', 'check responsive', 'breakpoint test', 'viewport test', 'responsive sweep', 'check breakpoints', or 'test at mobile'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Responsiveness Check

--- a/plugins/dev-tools/skills/roadmap/SKILL.md
+++ b/plugins/dev-tools/skills/roadmap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: roadmap
 description: "Plan and execute entire application builds. Generates phased delivery roadmaps, then executes them autonomously — phase by phase, committing at milestones, deploying, testing, and continuing until done or stuck. Modes: plan (generate roadmap), start (begin executing), resume (continue from where you left off), status (show progress). Triggers: 'roadmap', 'plan the build', 'start building', 'resume the build', 'keep going', 'build the whole thing', 'execute the roadmap', 'what phase are we on'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools:
   - Read
   - Write

--- a/plugins/dev-tools/skills/team-update/SKILL.md
+++ b/plugins/dev-tools/skills/team-update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: team-update
 description: "Post project updates to team chat, gather feedback, triage responses, and plan next steps. Adapts to available tools (chat, git, issues, tasks). First run discovers tools and saves a playbook; subsequent runs execute from the playbook. Trigger with 'team update', 'post update', 'sync with team', 'standup', 'check team chat', 'feedback loop', 'project update', 'what did the team say'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools: "*"
 ---
 

--- a/plugins/dev-tools/skills/ux-compare/SKILL.md
+++ b/plugins/dev-tools/skills/ux-compare/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-compare
 description: "Compare UX patterns across multiple reference apps using pattern libraries produced by ux-extract. Reads 2+ pattern-library.md files, walks them category by category, identifies where apps converge (strong signal), where they diverge (genuine design choice), what's unique to one app, and what's absent across the set. Produces an opinionated comparison document with recommendations for a new build. No browser needed — pure markdown analysis. Trigger with 'compare UX patterns', 'how do top apps handle X', 'ux comparison', 'pattern comparison across reference apps'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # UX Compare

--- a/plugins/dev-tools/skills/ux-extract/SKILL.md
+++ b/plugins/dev-tools/skills/ux-extract/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-extract
 description: "Exhaustively extract UX patterns from a reference web app. Walks every screen, captures screenshots of every state, records interaction patterns, copy verbatim, keyboard shortcuts, responsive treatments, motion, and empty/error/loading states. Produces a reusable pattern library that other audits can compare against. The inverse of ux-audit — asks 'what is the bar?' rather than 'does this match the bar?'. Trigger with 'learn from X', 'extract patterns from X', 'study X's UX', 'reverse engineer the UX of X', 'build a pattern library from X'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # UX Extract

--- a/plugins/frontend/skills/design-loop/SKILL.md
+++ b/plugins/frontend/skills/design-loop/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Glob
   - Grep
   - Bash
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Design Loop — Autonomous Site Builder

--- a/plugins/frontend/skills/design-review/SKILL.md
+++ b/plugins/frontend/skills/design-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-review
 description: "Review a web app or page for visual design quality — layout, typography, spacing, colour, hierarchy, consistency, interaction patterns, and responsive behaviour. Not a UX audit (that checks usability) — this checks whether it looks professional and polished. Produces a design findings report with screenshots. Triggers: 'design review', 'does this look good', 'review the design', 'check the layout', 'is this polished', 'visual review', 'design audit', 'make it look better', 'it looks off'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Design Review

--- a/plugins/frontend/skills/design-system/SKILL.md
+++ b/plugins/frontend/skills/design-system/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Design System Extractor

--- a/plugins/frontend/skills/landing-page/SKILL.md
+++ b/plugins/frontend/skills/landing-page/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - Edit
   - Glob
   - Grep
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Landing Page Generator

--- a/plugins/frontend/skills/product-showcase/SKILL.md
+++ b/plugins/frontend/skills/product-showcase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-showcase
 description: "Generate a comprehensive marketing website for a web app — multi-page with real screenshots, animated GIF walkthroughs, feature deep-dives, and workflow demonstrations. Browses the running app, captures screens and sequences, and produces a deployable site that actually teaches people what the product does. Especially useful for complex or agentic apps that are hard to explain. Triggers: 'showcase site', 'product page', 'show off the app', 'marketing site', 'demo site', 'product showcase', 'explain the app', 'how do I market this'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Product Showcase Generator

--- a/plugins/frontend/skills/react-native/SKILL.md
+++ b/plugins/frontend/skills/react-native/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: react-native
 description: "React Native and Expo patterns for building performant mobile apps. Covers list performance, animations with Reanimated, navigation, UI patterns, state management, platform-specific code, and Expo workflows. Use when building or reviewing React Native code. Triggers: 'react native', 'expo', 'mobile app', 'react native performance', 'flatlist', 'reanimated', 'expo router', 'mobile development', 'ios app', 'android app'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools:
   - Read
   - Write

--- a/plugins/frontend/skills/react-patterns/SKILL.md
+++ b/plugins/frontend/skills/react-patterns/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: react-patterns
 description: "React 19 performance patterns and composition architecture for Vite + Cloudflare projects. 50+ rules ranked by impact — eliminating waterfalls, bundle optimisation, re-render prevention, composition over boolean props, server/client boundaries, and React 19 APIs. Use when writing, reviewing, or refactoring React components. Triggers: 'react patterns', 'react review', 'react performance', 'optimise components', 'react best practices', 'composition patterns', 'why is it slow', 'reduce re-renders', 'fix waterfall'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools:
   - Read
   - Glob

--- a/plugins/frontend/skills/shadcn-ui/SKILL.md
+++ b/plugins/frontend/skills/shadcn-ui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: shadcn-ui
 description: "Install and configure shadcn/ui components for React projects. Guides component selection, installation order, dependency management, customisation with semantic tokens, and common UI recipes (forms, data tables, navigation, modals). Use after tailwind-theme-builder has set up the theme infrastructure, when adding components, building forms, creating data tables, or setting up navigation."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # shadcn/ui Components

--- a/plugins/frontend/skills/tailwind-theme-builder/SKILL.md
+++ b/plugins/frontend/skills/tailwind-theme-builder/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when initialising React projects with Tailwind v4, setting up shadcn/ui theming,
   or fixing colors not working, tw-animate-css errors, @theme inline dark mode conflicts,
   @apply breaking, v3 migration issues.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Tailwind Theme Builder

--- a/plugins/frontend/skills/walkthrough-video/SKILL.md
+++ b/plugins/frontend/skills/walkthrough-video/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Walkthrough Video Generator

--- a/plugins/integrations/skills/elevenlabs-agents/SKILL.md
+++ b/plugins/integrations/skills/elevenlabs-agents/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Supports React, React Native, and Swift SDKs. Use when building voice agents,
   AI phone systems, or troubleshooting @11labs deprecated packages, webhook errors,
   CSP violations, localhost allowlist, or tool parsing errors.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # ElevenLabs Agent Builder

--- a/plugins/integrations/skills/google-apps-script/SKILL.md
+++ b/plugins/integrations/skills/google-apps-script/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-apps-script
 description: "Build Google Apps Script automation for Sheets and Workspace apps. Produces scripts with custom menus, triggers, dialogs, email automation, PDF export, and external API integration."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Google Apps Script

--- a/plugins/integrations/skills/google-chat-messages/SKILL.md
+++ b/plugins/integrations/skills/google-chat-messages/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-chat-messages
 description: "Send Google Chat messages via webhook — text, rich cards (cardsV2), threaded replies. Includes TypeScript types, card builder utility, and widget reference."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Google Chat Messages

--- a/plugins/integrations/skills/gws-install/SKILL.md
+++ b/plugins/integrations/skills/gws-install/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when setting up gws on a new computer, reinstalling after a fresh OS, or
   configuring a second workstation. Triggers: "install gws", "gws on new machine",
   "gws install", "set up gws again".
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Google Workspace CLI — Quick Install

--- a/plugins/integrations/skills/gws-setup/SKILL.md
+++ b/plugins/integrations/skills/gws-setup/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when setting up gws for the first time, configuring Google Workspace API access,
   or troubleshooting gws auth issues. Triggers: "set up gws", "google workspace cli",
   "gws setup", "install gws".
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Google Workspace CLI — First-Time Setup

--- a/plugins/integrations/skills/mcp-builder/SKILL.md
+++ b/plugins/integrations/skills/mcp-builder/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when creating MCP servers, exposing tools/resources/prompts to LLMs,
   building Claude integrations, or troubleshooting FastMCP module-level server,
   storage, lifespan, middleware, OAuth, or deployment errors.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # MCP Builder

--- a/plugins/integrations/skills/nemoclaw-setup/SKILL.md
+++ b/plugins/integrations/skills/nemoclaw-setup/SKILL.md
@@ -6,7 +6,7 @@ description: >
   remote access via Cloudflare Tunnel, and known bug workarounds.
   Triggers: "install nemoclaw", "setup nemoclaw", "nvidia nemoclaw", "openclaw setup",
   "nemoclaw on spark", "nemoclaw on dgx".
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # NemoClaw Setup

--- a/plugins/integrations/skills/stripe-payments/SKILL.md
+++ b/plugins/integrations/skills/stripe-payments/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: stripe-payments
 description: "Add Stripe payments to a web app — Checkout Sessions, Payment Intents, subscriptions, webhooks, customer portal, and pricing pages. Covers the decision of which Stripe API to use, produces working integration code, and handles webhook verification. No MCP server needed — uses Stripe npm package directly. Triggers: 'add payments', 'stripe', 'checkout', 'subscription', 'payment form', 'pricing page', 'billing', 'accept payments', 'stripe webhook', 'customer portal'."
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 allowed-tools:
   - Read
   - Write

--- a/plugins/shopify/skills/shopify-content/SKILL.md
+++ b/plugins/shopify/skills/shopify-content/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Workflow: determine content type, generate content, create via API or browser, verify.
   Use when creating pages, writing blog posts, updating navigation menus,
   managing redirects, or updating SEO metadata on a Shopify store.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Shopify Content

--- a/plugins/shopify/skills/shopify-products/SKILL.md
+++ b/plugins/shopify/skills/shopify-products/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Workflow: gather product data, choose method (API or CSV), execute, verify.
   Use when adding products, bulk importing, updating variants, managing inventory,
   uploading product images, or assigning products to collections.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Shopify Products

--- a/plugins/shopify/skills/shopify-setup/SKILL.md
+++ b/plugins/shopify/skills/shopify-setup/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Workflow: install CLI, authenticate, create custom app, store access token, verify.
   Use when connecting to a Shopify store, setting up API access, or troubleshooting
   auth issues with Shopify CLI or Admin API tokens.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # Shopify Setup

--- a/plugins/wordpress/skills/wordpress-content/SKILL.md
+++ b/plugins/wordpress/skills/wordpress-content/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Workflow: determine content type, choose method (WP-CLI or REST API), execute, verify.
   Use when creating blog posts, updating pages, uploading media, managing categories
   and tags, updating menus, or doing bulk content operations on WordPress sites.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # WordPress Content

--- a/plugins/wordpress/skills/wordpress-elementor/SKILL.md
+++ b/plugins/wordpress/skills/wordpress-elementor/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Use when editing Elementor pages, updating text in Elementor widgets,
   applying or managing Elementor templates, or making content changes
   to pages built with Elementor page builder.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # WordPress Elementor

--- a/plugins/wordpress/skills/wordpress-setup/SKILL.md
+++ b/plugins/wordpress/skills/wordpress-setup/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Workflow: check CLI, test SSH connection, set up auth, verify access, save config.
   Use when connecting to a WordPress site, setting up WP-CLI access, creating
   application passwords, or troubleshooting WordPress connection issues.
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # WordPress Setup


### PR DESCRIPTION
## Two coherent changes

### 1. README

Adds a **compatibility badge** + short section acknowledging the [agentskills.io](https://agentskills.io) ecosystem. Claude Code remains the primary build/test target — but the spec is now an open standard adopted by ~35 tools, and these skills load in any compliant agent.

```diff
-Production workflow skills for Claude Code.
+Production workflow skills for Claude Code. Each skill guides an agent through…

+## Compatibility
+
+These skills follow the agentskills.io open standard…
+the ecosystem currently includes Cursor, VS Code Copilot, OpenAI Codex,
+Gemini CLI, OpenHands, Goose, Letta, and ~30 others.
+Install mechanics differ per tool; the skill content is portable.
```

### 2. `compatibility` sweep

**51 SKILL.md files** previously declared `compatibility: claude-code-only`. That's technically valid per the spec (the field is free-form up to 500 chars) but is prescriptively exclusive — telling other compliant agents "don't bother loading me."

Swept to the spec's own inclusive example phrasing:

```diff
-compatibility: claude-code-only
+compatibility: Designed for Claude Code (or similar products)
```

Same fact (Claude Code is the primary target), inclusive framing. Other compliant agents aren't locked out — they can load, read, and follow the skill; UX may differ (e.g. slash-command features), but the instructions are portable.

## Why now

The agentskills.io spec (Anthropic-originated, now open) has grown to ~35 adopting tools. Our 661-star public repo has been building to this spec since day one. Current framing was tighter than necessary — this sweep aligns positioning with actual portability without changing any code behaviour.

## Verification

Spot-checked 3 swept skills — all pass `skills-ref validate`:

```
$ npx skills-ref@0.1.5 validate plugins/cloudflare/skills/cloudflare-worker-builder
Valid skill: …
$ npx skills-ref@0.1.5 validate plugins/dev-tools/skills/ux-audit
Valid skill: …
$ npx skills-ref@0.1.5 validate plugins/shopify/skills/shopify-setup
Valid skill: …
```

CI runs the full validator on every PR via the new workflow step in [#78](https://github.com/jezweb/claude-skills/pull/78).

## Companion PRs

Three PRs form a coherent agentskills.io-alignment trio:

| PR | Scope |
|---|---|
| [#77](https://github.com/jezweb/claude-skills/pull/77) | `brains-trust` frontmatter fix (spec compliance 85 → 86) |
| [#78](https://github.com/jezweb/claude-skills/pull/78) | CI step: `skills-ref validate` alongside `skill-lint` |
| #79 (this) | README + 51-file compatibility sweep (positioning) |

Companion on `jez-skills`: [#12](https://github.com/jezweb/jez-skills/pull/12) (`create-l2chat-agent` same fix as #77).

Together: 87/87 spec compliance + CI enforcement + marketing acknowledgement that lands our 661-star repo cleanly in the agentskills.io ecosystem.

## Non-goals

This PR doesn't audit whether each skill's *instructions* are functionally portable across tools — only that the skill format declares inclusive compatibility. Some skills use Claude-Code-specific MCP tools or `Task`/`Skill` invocations that other agents may not support; end-user experience will vary. The README note is explicit: "skill content is portable" (format-level), "Install mechanics differ per tool."