### PR TITLE
ux-audit: component-state matrix + lifecycle-position scenario

### DIFF
--- a/plugins/dev-tools/commands/ux-audit.md
+++ b/plugins/dev-tools/commands/ux-audit.md
@@ -1,5 +1,5 @@
 ---
-description: Exhaustively audit a web app — threads, elements, 8 scenarios, fix-and-verify loop
+description: Exhaustively audit a web app — threads, elements, 6 component states, 9 scenarios, fix-and-verify loop
 argument-hint: "[optional: persona or scope, e.g. 'as a busy broker' or 'the dashboard only']"
 allowed-tools: "*"
 ---

--- a/plugins/dev-tools/skills/ux-audit/SKILL.md
+++ b/plugins/dev-tools/skills/ux-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-audit
-description: "Exhaustive UX audit of a web app. Walks every thread a real user would follow, tests every interactive element, runs scenario battery (keyboard-only, heavy data, destructive actions, second user, interrupted workflow, wrong turn, returning user, first contact), produces ranked findings with screenshots, then offers a fix-and-verify loop. Requires a persona. Trigger with 'ux audit', 'dogfood this', 'audit the app', 'qa sweep', 'exhaustive test', 'check all pages'."
-compatibility: claude-code-only
+description: "Exhaustive UX audit of a web app. Walks every thread a real user would follow, tests every interactive element including all six component states (default, skeleton, empty, partial, error, disabled), runs nine-scenario battery (first contact, interrupted workflow, wrong turn, returning user, keyboard only, heavy data, destructive confidence, second user role, lifecycle position), produces ranked findings with screenshots, then offers a fix-and-verify loop. Requires a persona. Trigger with 'ux audit', 'dogfood this', 'audit the app', 'qa sweep', 'exhaustive test', 'check all pages'."
+compatibility: Designed for Claude Code (or similar products)
 ---
 
 # UX Audit
@@ -11,7 +11,7 @@ Exhaustively audit a web app from the perspective of a real user. Two lenses, co
 - **Flow lens** — walk the 3–5 real tasks a user would do ("threads"). Count clicks, mark dead ends, screenshot every state change.
 - **Element lens** — after threads, sweep every interactive element not already hit. Forms, menus, toggles, edge data volumes.
 
-Then run an eight-scenario battery (first contact, interrupted workflow, wrong turn recovery, returning user, keyboard only, heavy data, destructive confidence, second user) and close with a fix-and-verify loop for critical findings.
+Then run a nine-scenario battery (first contact, interrupted workflow, wrong turn recovery, returning user, keyboard only, heavy data, destructive confidence, second user by role, lifecycle position) and close with a fix-and-verify loop for critical findings.
 
 This is the thorough one. There is no quick mode. If the user wants a targeted check ("audit the dashboard"), scope the audit to that area — but within that area, still go exhaustive. Runtime is unbounded: assume a long-running session, write findings to the report incrementally, don't batch.
 
@@ -168,6 +168,23 @@ For **every list/table**, test at these volumes if data permits:
 - 100 items (pagination)
 - 1000+ items (virtualisation, search, filter performance)
 
+### Component state matrix
+
+For each major content component (list, card, table, dashboard widget, form, detail panel), capture all six visual states. Most teams design the default state in detail and ship the others by default — that's where the bugs hide.
+
+| State | What to verify | Common findings |
+|-------|----------------|-----------------|
+| **Default** | Loaded, idle | Baseline |
+| **Loading (skeleton)** | Shape parity with loaded layout — same column widths, same row heights, same number of placeholder elements. Skeleton stays for the *minimum* of (real load time, ~300ms) so it never flashes. | Spinner-on-blank-container instead of a skeleton; skeleton shape doesn't match what loads (layout shift); skeleton flashes for 50ms then disappears. |
+| **Empty** | Helpful copy + CTA. Speaks to the user's *next action*, not just "no data". | Blank void; column headers with zero rows; copy that says "no data" without explaining how to get some. |
+| **Partial loaded** | First batch usable while later batches arrive. No pretending the whole thing loaded when half is still pending. | Misleading "complete" framing while data still streams in; no progress indication on long loads; blocking UI on data that should be progressive. |
+| **Error** | Recoverable? Retry available? Distinguishes *can't reach* from *forbidden* from *invalid input*. | Generic "Something went wrong"; raw stack trace leaked; no retry path; permission errors styled identically to network errors. |
+| **Disabled** | Why disabled is *visible* (tooltip, helper text, or adjacent copy). Path to enable is implied or stated. | Greyed-out button with no tooltip; user has no idea what unlocks it. |
+
+Skeleton loaders deserve a specific check — a spinner on top of a blank container is **not** a skeleton. The skeleton's job is to *prevent layout shift* and *signal what's coming*. Verify both: throttle the network (DevTools → Network → Slow 3G or offline) to force the loading state to stay visible long enough to inspect.
+
+Hover, focus, and active visual states fall under thread traversal's filmstrip — capture them there, not here, since they're meaningful only in the context of pointer/keyboard interaction.
+
 Write findings to the report as you go. Don't hold them in memory.
 
 ## Responsive Sweep
@@ -190,7 +207,7 @@ Run the automated layout-detection JS (overflow, clipping, invisible text) at ea
 
 ## Scenario Battery
 
-Eight scenarios. All eight, always. They catch what screen-by-screen testing misses. Full protocols in [references/scenario-tests.md](references/scenario-tests.md).
+Nine scenarios. All nine, always. They catch what screen-by-screen testing misses. Full protocols in [references/scenario-tests.md](references/scenario-tests.md).
 
 1. **First Contact** — figure out the app with zero prior knowledge, then write a 2-minute plain-English guide to each thread. Gaps in the guide are UX gaps.
 2. **Interrupted Workflow** — start a task, close the tab, refresh, navigate away mid-form. Does state survive?
@@ -199,7 +216,62 @@ Eight scenarios. All eight, always. They catch what screen-by-screen testing mis
 5. **Keyboard Only** — unplug the mouse. Can every thread complete keyboard-only? Focus visible? Tab order logical? Escape closes?
 6. **Heavy Data** — seed with 500+ records. Lists virtualise? Search returns the right thing? Filters narrow meaningfully?
 7. **Destructive Confidence** — for every delete, send, publish, pay, share: is consent clear? Does confirm copy tell you what's about to happen? Undo available?
-8. **Second User** — log in as a restricted role (viewer not editor, client not staff). Read-only views coherent? Permissions errors make sense?
+8. **Second User (Role)** — log in as a restricted role (viewer not editor, client not staff). Read-only views coherent? Permissions errors make sense?
+9. **Lifecycle Position** — same role, different position in time. Test as user #1 (founder, fresh org, sets everything up), user #2 (first invitee, lands in partial state, no setup wizard), and user #N (later joiner, fully populated workspace). Each sees a different reality. Onboarding flows, empty/partial/full state copy, defaults, and peer-feature UIs (mentions, assignments, activity feeds) all differ.
+
+## Live Interaction Smoke
+
+Code reading verifies a button exists and has an `onClick`. It does not
+verify that clicking the button actually **does something observable**.
+Bugs of this shape — "the handler runs, fires a call into an SDK, but
+the flow never completes" — are invisible to static analysis and
+require a live click + network check.
+
+Run these for every **interactive control** on every page:
+
+1. **Click it.** Pointer moves, element highlights, click lands.
+2. **Watch the Network tab.** Did a request fire? To the right URL?
+   Correct method + body shape?
+3. **Watch the DOM.** Did something visibly change — new element,
+   removed element, state transition (loading spinner, toast, route
+   change)?
+4. **If nothing changed in (2) or (3), that's a bug.** The control
+   LOOKS alive but isn't doing its job. Log it.
+
+### Known control categories that silently fail
+
+| Control category | Silent-failure mode to watch for |
+|---|---|
+| Approve / Deny buttons on tool-call cards | Handler fires but server never hears about it (SDK needs a separate "send on state change" callback). See `rules/ai-sdk-tool-approval-autosubmit.md`. |
+| "Connect X" OAuth buttons inside dialogs | `window.open()` silently popup-blocked when click originates in a modal. Must use `window.location.href`. See `rules/oauth-popup-blocked-in-dialogs.md`. |
+| Save / update buttons on forms with async validation | Button disables during mutation but the mutation itself silently 5xx'd. No toast, no error state, form just sits there. |
+| Delete / archive actions | Optimistic UI removes the row but server rejected — after refresh, the row is back. |
+| Pagination / "Load more" buttons | Fires request but response empty due to off-by-one offset. |
+| Filter chips on list views | Query param updates but query key doesn't — TanStack Query serves stale cached results. |
+| "Reply" / "Forward" in email-style UIs | Opens compose pane but Message-ID headers not set — reply threads orphan in recipient's inbox. |
+
+### SDK contract check
+
+When the page uses a third-party SDK with its own state model, verify
+the SDK's required options are passed. Silent failures usually trace
+to an undocumented-but-required option.
+
+Common SDK contracts to verify:
+
+| SDK | Option that silently breaks behaviour if missing |
+|---|---|
+| `@ai-sdk/react` useChat with `needsApproval: true` tools | `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` |
+| `@ai-sdk/react` useChat with custom transport | `prepareSendMessagesRequest` reading latest refs (otherwise pinned to initial values) |
+| better-auth `createAuthClient` | `sessionOptions.refetchOnWindowFocus: false` for SPAs that route on session state |
+| TanStack Query `QueryClient` | `refetchOnWindowFocus: false` if your app redirects on empty query results |
+| React Router v7 `createBrowserRouter` | `loader` / `action` defined for routes that need data (not just component) |
+| Radix Dialog | `modal: true` + `onEscapeKeyDown` handler if Escape should do more than close |
+| zodResolver | `as any` around schema if using Zod v4 and resolver is older — silent validation miss |
+
+**If the page uses an SDK not on this list**, spend 2 minutes reading
+its "useX" export's options. Anything named `*On*Change`, `*On*Finish`,
+`*SendAutomatically*`, `*RefetchOn*`, or `*Configure*` is a prime
+suspect for "silent failure because it's undefined."
 
 ## Passive Error Sweeps
 
@@ -283,7 +355,6 @@ Three principles for audit runs that catch the most bugs:
 1. **Drive the audit from the main session, not a sub-agent.** Sub-agents are fine for bounded analysis tasks (reviewing a batch of captured screenshots, summarising a thread). But the audit *itself* — the navigation, the noticing, the "this button looks off after the previous interaction" kind of judgement — must happen in the session that's been watching the app. Cross-interaction state lives in that session's working memory; a fresh sub-agent starts cold and misses second-order findings.
 
 2. **Use the browser tool directly.** Chrome MCP or Playwright MCP via the main session's tool calls. Don't hand screenshots to a fresh agent and ask for opinions — that loses the state-dependence that makes audits catch logic errors, business-logic issues, and odd edge cases.
-
 3. **Loop to exhaustion with variations.** Don't stop after one pass through the checklist. After each pass, generate a new angle — different persona, different workflow, different input volume, different starting point, different validation lens — and re-walk. Stop only when a full pass produces no new findings. Single-pass audits by definition miss the second-order issues.
 
 For audits expected to run longer than 30 minutes, set up a 15-min `/loop` check-in alongside the main session — it journals findings, grounds the session, and provides a natural termination signal. See [references/long-running-check-in-pattern.md](references/long-running-check-in-pattern.md).

--- a/plugins/dev-tools/skills/ux-audit/references/report-template.md
+++ b/plugins/dev-tools/skills/ux-audit/references/report-template.md
@@ -25,7 +25,8 @@ Write incrementally — open the file at the start of the audit, append as you g
 | Routes | 14 | 14 | 100% |
 | Interactive elements | 187 | 203 | 92% |
 | Threads walked | 4 | 4 | 100% |
-| Scenarios completed | 7 | 8 | 88% (Destructive Confidence skipped — no test account) |
+| Scenarios completed | 8 | 9 | 89% (Destructive Confidence skipped — no test account) |
+| Component states sampled | 4/6 | 6 | 67% (Partial loaded + Disabled not reproducible on tested components) |
 
 **Elements not tested** (and why):
 - /app/billing — 16 elements — requires paid plan, not available on test account
@@ -143,11 +144,34 @@ Write incrementally — open the file at the start of the audit, append as you g
 | Delete client | [copy quality] | Y/N | Y/N | |
 | Send invoice | [copy] | Y/N | Y/N | |
 
-### Second User ([role tested])
+### Second User — Role ([role tested])
 
 | Thread | Completable as [role] | Broken pages | Leaked data | Error quality |
 |--------|----------------------|--------------|-------------|--------------|
 | Thread 1 | Y/N | [list] | [list] | [assessment] |
+
+### Lifecycle Position
+
+| Position | Setup flow shown? | Onboarding gap | Wayfinding works? | Empty/partial UI helpful? |
+|----------|-------------------|----------------|-------------------|--------------------------|
+| User #1 (founder) | Y/N + quality | [list] | Y/N + detail | Y/N + detail |
+| User #2 (first invitee) | Y/N + quality | [list] | Y/N + detail | Y/N + detail |
+| User #N (later joiner) | Y/N + quality | [list] | Y/N + detail | Y/N + detail |
+
+- **Same-screen-three-faces coherence**: [pages where empty / partial / full all looked considered, vs pages where one looked unfinished]
+- **Onboarding scope creep**: [setup UI that bleeds into screens it shouldn't]
+- **Peer-feature dignity** (mentions, assignments, activity feeds with 1 / 2 / 50 users): [findings]
+- **Default landing differentiation**: [does it adapt by lifecycle position, or one-size-fits-most]
+
+## Component States
+
+For each major component sampled, capture which of the six states were verified:
+
+| Component | Default | Skeleton | Empty | Partial | Error | Disabled | Notes |
+|-----------|---------|----------|-------|---------|-------|----------|-------|
+| Clients list | ✓ | ✗ (spinner not skeleton) | ✓ | n/a | ✓ | n/a | Spinner-on-blank, no shape signal |
+| Dashboard widgets | ✓ | ✓ | ✗ (blank void) | ✓ | ✗ (silent fail) | n/a | Empty + Error need work |
+| Save button (forms) | ✓ | n/a | n/a | n/a | ✓ | ✓ (no tooltip) | Disabled state has no "why" |
 
 ## Network Errors (detected during browsing)
 

--- a/plugins/dev-tools/skills/ux-audit/references/scenario-tests.md
+++ b/plugins/dev-tools/skills/ux-audit/references/scenario-tests.md
@@ -1,6 +1,6 @@
 # Scenario Tests
 
-Eight structured tests that go beyond page-by-page evaluation. Each simulates a real-world situation that exposes problems traditional QA misses. Run all eight during an exhaustive audit.
+Nine structured tests that go beyond page-by-page evaluation. Each simulates a real-world situation that exposes problems traditional QA misses. Run all nine during an exhaustive audit.
 
 ---
 
@@ -287,7 +287,7 @@ Plus:
 
 ---
 
-## 8. Second User
+## 8. Second User (Role)
 
 **Premise**: Most apps have roles — admin vs viewer, staff vs client, owner vs guest. The primary user experience is tested exhaustively. What about the others?
 
@@ -319,6 +319,68 @@ Plus:
 
 ---
 
+## 9. Lifecycle Position
+
+**Premise**: Same role can experience the app radically differently depending on *when* in the org's lifecycle the user joins. The primary user gets exhaustive testing from a fully-onboarded perspective. What about the founder on day one, the first invitee on day three, and the colleague who joined a workspace that already has a year of history?
+
+These are different products to different users. Empty-state copy that says "Get started by adding your first user" is correct for user #1 and broken for user #2. Activity feeds that look great with 50 contributors may break or feel hollow with one. Defaults that filter to "your work" are great for user #N and meaningless for user #1.
+
+**How to run**:
+
+Test three lifecycle positions, each with the same role (e.g. admin):
+
+### User #1 — Founder (fresh org)
+
+1. Sign up a fresh account / create a new org / start a new workspace.
+2. Walk the *initial setup* and *first meaningful task* as the persona.
+3. Specifically check:
+   - **Onboarding flow**: Was there one? Was it skippable? Did it explain the app's concepts or assume you knew them?
+   - **Empty workspace**: Helpful or hostile? Did the dashboard guide the next action or just show "no data" everywhere?
+   - **First-task time**: Could you complete one meaningful piece of work in 5 minutes?
+   - **Concept introduction**: Did the app teach its own vocabulary as you encountered it, or did you have to figure it out?
+
+### User #2 — First invitee (partial state)
+
+1. From user #1's account, invite user #2 with the same role.
+2. Accept the invite as user #2 and walk the same threads as user #1.
+3. Specifically check:
+   - **Invite welcome**: Did the welcome copy address you specifically, or did it dump you into the founder's setup wizard?
+   - **Setup-wizard misfire**: Were you forced through "set up your org" UI when the org already exists?
+   - **Wayfinding in partial state**: Could you find your way around an org someone else shaped, with limited data and one peer?
+   - **Peer-feature edge cases**: Mentions, assignments, comments, activity feeds, sharing — do they work meaningfully when there's only one other user?
+   - **Empty-with-context copy**: Does empty-state copy still say "Add your first user" when *you are* the first user being added?
+
+### User #N — Later joiner (full workspace)
+
+1. Either use a real workspace with established data, or seed a fresh org with rich state (50+ records, 5+ users, established saved views) before running this segment.
+2. Join as user #N (or simulate by seeding then signing up).
+3. Specifically check:
+   - **Onboarding stays out of the way**: You're catching up, not setting up. Does the app skip founder-flavoured onboarding?
+   - **Find your work**: Could you find what's *yours* amongst others' content? Defaults filtered to your context, or dumped into "all data"?
+   - **Convention learning**: Did the app teach the org's saved views, custom fields, naming conventions — or did you have to ask a teammate?
+   - **Joining-the-party UI**: Is there a "what you missed" / "what's relevant to you" affordance, or do you land in a generic dashboard?
+
+**What to report**:
+
+| Position | Setup flow shown? | Onboarding gap | Wayfinding works? | Empty/partial UI helpful? |
+|----------|-------------------|----------------|-------------------|--------------------------|
+| User #1 (founder) | Y/N + quality | [list gaps] | Y/N + detail | Y/N + detail |
+| User #2 (first invitee) | Y/N + quality | [list gaps] | Y/N + detail | Y/N + detail |
+| User #N (later joiner) | Y/N + quality | [list gaps] | Y/N + detail | Y/N + detail |
+
+Plus:
+- **Same-screen-three-faces inventory**: For each major page, is the empty / partial / full state coherent? Or does one of the three look unfinished?
+- **Onboarding scope creep**: Does setup UI bleed into screens user #2 and #N see?
+- **Activity feed dignity**: Does the app present activity sensibly when only one user has acted, or does it look hollow?
+- **Assignment / mention UX**: Test mentioning user #1 → user #2 with two-user setup. Does the @mention picker work? Are assignment dropdowns useful with 1, 2, 50 users?
+- **Default landing**: Does the default dashboard / home view differ usefully by lifecycle position, or is it identical-and-suboptimal-for-most?
+
+**Severity guide**: User #2 force-routed through founder setup wizard is **High**. Empty-state copy that's wrong for the user's lifecycle position ("Add your first user" shown to user #2) is **High**. Activity feed that breaks or shows raw nulls when only one user has acted is **High**. User #N dumped into all-data with no filter / scoping hint is **Medium**. Concept vocabulary never introduced anywhere (must learn from a teammate) is **Medium**. Onboarding shown to user #N when they don't need it (and unskippable) is **Medium**.
+
+**Why this beats the standard "second user" test**: Roles and lifecycle position are orthogonal axes. A viewer who joined on day one and a viewer who joined on day three hundred see different products. Scenario 8 covers the role axis. This covers the time axis.
+
+---
+
 ## Running the Battery
 
 Recommended order:
@@ -331,6 +393,7 @@ Recommended order:
 6. **Returning User** — repeat threads, measure improvement, check the dashboard.
 7. **Keyboard Only** — unplug the mouse, re-walk the threads.
 8. **Destructive Confidence** — ask the user before running. Use a test account if possible.
-9. **Second User** — log out, log in as a restricted role.
+9. **Second User (Role)** — log out, log in as a restricted role.
+10. **Lifecycle Position** — fresh org as user #1, invited as user #2, joining a populated org as user #N.
 
-The First Contact output goes directly into the report and doubles as user documentation draft. The Destructive Confidence and Second User results often surface the highest-severity findings in the whole audit.
+The First Contact output goes directly into the report and doubles as user documentation draft. The Destructive Confidence, Second User, and Lifecycle Position results often surface the highest-severity findings in the whole audit.


### PR DESCRIPTION
Closes #80.

Two coverage gaps in `ux-audit` closed.

## What's new

### 1. Component State Matrix (Element Exhaustion)

For each major content component (list, card, table, dashboard widget, form, detail panel), capture all six visual states:

| State | What to verify | Common findings |
|-------|----------------|-----------------|
| Default | Loaded, idle | Baseline |
| Loading (skeleton) | Shape parity with loaded layout | Spinner-on-blank instead of skeleton; layout shift on load |
| Empty | Helpful copy + CTA | Blank void; "no data" without next-action |
| Partial loaded | First batch usable while later arrive | Misleading "complete" framing while still streaming |
| Error | Recoverable? Distinguishes can't-reach vs forbidden vs invalid | Generic "Something went wrong"; raw stack trace; no retry |
| Disabled | "Why" is visible (tooltip / helper / adjacent copy) | Greyed-out button with no path to enable |

Skeleton loaders get specific scrutiny — a spinner over a blank container isn't a skeleton.

### 2. Scenario 9 — Lifecycle Position

Same role, different position in time. Three test passes:

- **User #1 (Founder)** — fresh org, sees onboarding, sets everything up, blank-everything state
- **User #2 (First invitee)** — lands in partial state, no setup wizard, peer-features tested with one teammate
- **User #N (Later joiner)** — fully populated workspace, defaults assume rich data

Orthogonal to scenario 8 (which is about *role*). Scenario 8 renamed to "Second User (Role)" to disambiguate from the new lifecycle-position axis.

## Files changed

- `plugins/dev-tools/skills/ux-audit/SKILL.md` — description, Element Exhaustion sub-section, scenario list 8 → 9
- `plugins/dev-tools/skills/ux-audit/references/scenario-tests.md` — full Scenario 9 protocol (three-position test matrix, severity guide)
- `plugins/dev-tools/skills/ux-audit/references/report-template.md` — Lifecycle Position table, Component States table, coverage row
- `plugins/dev-tools/commands/ux-audit.md` — description sync per `~/.claude/rules/plugin-skill-descriptions.md`

## Bundled WIP

This commit also lands a small previously-unstaged WIP on the same skill — a `compatibility` frontmatter wording fix and a new "Live Interaction Smoke" section covering silent-failure controls (Approve/Deny buttons, OAuth-in-dialog popups, async-validation forms, etc.) and SDK contract checks. Same skill, same theme — kept together rather than split into a stale separate branch.

## Test plan

- [x] `bin/skill-lint plugins/dev-tools/skills/ux-audit` passes (380 lines, under 500-line cap)
- [x] Frontmatter description trigger phrases preserved (`'ux audit'`, `'dogfood this'`, `'audit the app'`, etc.)
- [x] Command file description in sync with SKILL.md description (per shared rule)
- [ ] Spot-check next time someone runs `/ux-audit` — verify Scenario 9 is picked up and the Component State Matrix sub-section is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)