### PR TITLE
ux-audit: project-adaptation reference for non-default stacks

### DIFF
--- a/plugins/dev-tools/skills/ux-audit/SKILL.md
+++ b/plugins/dev-tools/skills/ux-audit/SKILL.md
@@ -56,7 +56,7 @@ axe-core thresholds are run **per page** (>1 violation on any single page fails)
 
 ### Allowlist for known noise
 
-Some apps have known-noisy console / network categories that aren't bugs (Sentry info logs in dev, browser-extension chatter, expected 401 on auth-check probes). The audit reads `.jez/audit-config.yml` (or `.json`) before Phase 3 and applies the allowlist when classifying findings. Allowlisted entries stay in the Interaction Manifest (transparency) but suppress from the findings count. The verdict block always shows both raw and allowlisted counts — `Console warnings: 3 (1 allowlisted, 2 reportable)`.
+Some apps have known-noisy console / network categories that aren't bugs (Sentry info logs in dev, browser-extension chatter, expected 401 on auth-check probes). The audit reads an audit-config file before Phase 3 and applies the allowlist when classifying findings. Path fallback chain: `.jez/audit-config.yml` → `audit-config.yml` (project root) → `.audit/config.yml`. Allowlisted entries stay in the Interaction Manifest (transparency) but suppress from the findings count. The verdict block always shows both raw and allowlisted counts — `Console warnings: 3 (1 allowlisted, 2 reportable)`.
 
 Default without a config: every console error / warning is a finding. Allowlist is opt-in per project, not a global escape hatch. Full format, semantics, surface overrides, and quarterly-audit discipline in [references/audit-config.md](references/audit-config.md).
 
@@ -83,7 +83,7 @@ The audit needs a persona before anything else. Without a locked persona, findin
 Source the persona in this order:
 
 1. **Argument** — if the user provided one ("ux audit as a busy insurance broker")
-2. **Project personas** — read `.jez/audit-personas/<slug>.md`, `.jez/personas/default.md`, or `.jez/personas/<app-name>.md` if they exist
+2. **Project personas** — read existing persona files (fallback chain: `.jez/audit-personas/<slug>.md` → `docs/personas/<slug>.md` → `personas/<slug>.md` → `.audit/personas/<slug>.md`). The first match wins.
 3. **Ask once** — *"Who uses this app and what are they trying to get done?"*
 
 Capture: role, tech comfort, time pressure, emotional state, device context. A good persona predicts what they'd miss ("A receptionist between phone calls won't scroll below the fold").
@@ -108,14 +108,7 @@ See [references/browser-tools.md](references/browser-tools.md) for commands.
 
 ### 3. URL
 
-Prefer the deployed/live version — that's what real users see.
-
-1. Check `wrangler.jsonc` for `pattern` or `custom_domain`
-2. Check CLAUDE.md, README, `package.json` `homepage` field
-3. Fall back to `lsof -i :5173 -i :3000 -i :8787 -t` for a running dev server
-4. Ask the user
-
-Live site has real auth, real latency, real CDN and CORS behaviour. Local misses deployment-specific bugs. Only use local if the user asks or the feature isn't deployed.
+Prefer the deployed/live version — real auth, real latency, real CDN and CORS. Discovery: read project CLAUDE.md / README for "URL" → check stack config (`wrangler.jsonc`, `vite.config.ts`, `next.config.js`, `config/database.yml`, `manage.py`, `.env` `APP_URL`, `wp-config.php`) → `lsof -i :PORT` (common: 5173 Vite, 3000 Next/Rails, 8000 Django/Laravel, 8787 Wrangler, 4321 Astro) → ask. Stack-specific guide in [references/project-adaptation.md](references/project-adaptation.md). Use local only if the user asks or the feature isn't deployed.
 
 ### 4. Viewport
 
@@ -292,7 +285,7 @@ For every audited page:
 3. Map violations → audit findings (axe `critical` → audit Critical, axe `serious` → audit High, etc).
 4. Hard-gate: > 0 axe Critical OR > 0 axe Serious on any page = audit Fails.
 
-Total runtime for a 16-route audit is ~16 seconds. Allowlist via `.jez/audit-config.yml` for builder-mode reference pages (Components, Style guide). Full snippet, severity mapping, and findings format in [references/a11y-automation.md](references/a11y-automation.md).
+Total runtime for a 16-route audit is ~16 seconds. Allowlist via the project's audit-config (path fallback chain in [references/audit-config.md](references/audit-config.md)) for builder-mode reference pages (Components, Style guide). Full snippet, severity mapping, and findings format in [references/a11y-automation.md](references/a11y-automation.md).
 
 ### Performance budget (pragmatic, mandatory)
 
@@ -420,7 +413,7 @@ Closes the loop in one session instead of waiting for tomorrow's audit.
 
 ## Cross-reference with ux-extract and brains-trust
 
-If a pattern library exists at `.jez/artifacts/ux-extracts/<ref>.md` or `docs/ux-extracts/<ref>.md`, read it before starting and use it as the bar for findings.
+If a pattern library exists (fallback chain: `.jez/artifacts/ux-extracts/<ref>.md` → `docs/ux-extracts/<ref>.md` → `audits/extracts/<ref>.md`), read it before starting and use it as the bar for findings.
 
 After v2 produces a verdict, consider running `dev-tools:brains-trust` to get a second-opinion review from a different model. v2 catches a class; brains-trust catches what your specific model habit misses. Recommended cadence: every 4-6 weeks.
 
@@ -466,6 +459,7 @@ For audits expected to run > 30 minutes, set up a 15-min `/loop` check-in alongs
 | When | Read |
 |------|------|
 | **Cross-skill output discipline** (Top 5, self-critique, smallest-patch, proof-PASS, hold-this) | [references/audit-output-discipline.md](references/audit-output-discipline.md) |
+| **Project adaptation** — non-default stacks (NextAuth/Lucia/Devise/Django auth, Prisma/TypeORM/ActiveRecord seeds, WordPress/Rails/Django URL discovery, persona library by app type) | [references/project-adaptation.md](references/project-adaptation.md) |
 | Persona library + writing protocol + persona-overload pattern | [references/persona-lock.md](references/persona-lock.md) |
 | Auth expiry mid-audit — protocol + headless test-auth resumption | [references/auth-expired-handling.md](references/auth-expired-handling.md) |
 | Data seasoning horizons (Day 0 / 1 / 7 / 30) + project seed-script architecture | [references/data-seasoning.md](references/data-seasoning.md) |

--- a/plugins/dev-tools/skills/ux-audit/references/audit-config.md
+++ b/plugins/dev-tools/skills/ux-audit/references/audit-config.md
@@ -14,11 +14,16 @@ Without an escape hatch the audit drowns the report in non-findings, and the age
 
 The audit reads the first match in this order, before Phase 3 starts:
 
-1. `.jez/audit-config.yml`
+1. `.jez/audit-config.yml` (Jezweb convention)
 2. `.jez/audit-config.json`
-3. `audit-config.yml` (project root, only if `.jez/` doesn't exist)
+3. `audit-config.yml` (project root)
+4. `audit-config.json`
+5. `.audit/config.yml` (hidden-folder fallback)
+6. `.audit/config.json`
 
 If no file is found, default behaviour applies: every console error / warning is a finding, every 4xx on an auth page is a finding. The allowlist is opt-in per project, not a global escape hatch.
+
+For projects using a different convention (e.g. `quality/audit-config.yml` or `tests/audit/config.yml`), the audit honours whatever path is documented in the project's CLAUDE.md or README — the fallback chain above is for projects without an explicit convention.
 
 ## File format
 

--- a/plugins/dev-tools/skills/ux-audit/references/browser-tools.md
+++ b/plugins/dev-tools/skills/ux-audit/references/browser-tools.md
@@ -15,7 +15,9 @@ For public sites with no login, Playwright MCP is fine (and can run in parallel 
 
 If the project exposes a `/api/test-auth/cookies`-style endpoint (gated on a server-side `TEST_AUTH_TOKEN` secret), a headless agent can mint real session cookies and inject them into Playwright. This unlocks autonomous audits without requiring Chrome MCP.
 
-Pattern (project-agnostic — any better-auth project can expose this):
+The example below is **better-auth-specific**. NextAuth / Auth.js, Lucia, Rails Devise, Django auth, custom JWT, magic-link, and WordPress have different patterns — see [project-adaptation.md](project-adaptation.md) "Test-auth alternatives" for each. The general principle is the same across stacks: gate on a server-side env flag, use a token / shared secret, lock to email patterns like `*@test.<app>.local` to prevent real-user takeover.
+
+Pattern (better-auth example):
 
 ```bash
 # 1. Mint session cookies for a test user (creates if needed)

--- a/plugins/dev-tools/skills/ux-audit/references/data-seasoning.md
+++ b/plugins/dev-tools/skills/ux-audit/references/data-seasoning.md
@@ -103,7 +103,7 @@ Skip the scenario only if the app has zero time-distributed data — a one-shot 
 
 ## Project-side seed-script architecture
 
-The audit assumes the project provides seasoning seeds. Recommend this pattern:
+The audit assumes the project provides seasoning seeds. The example below uses **Cloudflare Workers + Drizzle + tsx**; for Prisma / TypeORM / Sequelize / ActiveRecord (Rails) / Django ORM / Laravel Eloquent / WordPress / raw SQL equivalents, see [project-adaptation.md](project-adaptation.md) "Seed-script architectures by ORM".
 
 ```
 scripts/

--- a/plugins/dev-tools/skills/ux-audit/references/live-interaction-smoke.md
+++ b/plugins/dev-tools/skills/ux-audit/references/live-interaction-smoke.md
@@ -38,6 +38,8 @@ This is a Hard Gate during Phase 3 walkthrough — silent-failure controls produ
 
 When the page uses a third-party SDK with its own state model, verify the SDK's required options are passed. Silent failures usually trace to an undocumented-but-required option.
 
+The catalogue below is **React + TanStack + Radix + better-auth flavoured** — that's one stack of many. Vue, Svelte, Angular, vanilla, native browser, WordPress / PHP, mobile (iOS / SwiftUI) all have equivalent "undocumented option that silently breaks" patterns. See [project-adaptation.md](project-adaptation.md) "SDK contract examples by ecosystem" for the equivalents in each. The discipline is universal: any ecosystem's SDKs have a class of "if you don't pass this option, it silently does the wrong thing".
+
 | SDK | Option that silently breaks behaviour if missing |
 |---|---|
 | `@ai-sdk/react` useChat with `needsApproval: true` tools | `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` |

--- a/plugins/dev-tools/skills/ux-audit/references/persona-lock.md
+++ b/plugins/dev-tools/skills/ux-audit/references/persona-lock.md
@@ -74,7 +74,7 @@ all herself. Knows her business cold; isn't a software person.
 
 ## Persona library examples
 
-Common patterns the audit should adopt depending on the product:
+Common patterns the audit should adopt depending on the product. The personas below skew B2B-SaaS / dev-tooling — for consumer / e-commerce / CMS / mobile-first / WordPress / agency project types, see [project-adaptation.md](project-adaptation.md) "Persona library by app type".
 
 ### SME owner
 Time-pressed, low tech comfort, mobile-first, hates jargon. Wants tasks completed in 1-2 clicks. Triggers at acronyms.

--- a/plugins/dev-tools/skills/ux-audit/references/project-adaptation.md
+++ b/plugins/dev-tools/skills/ux-audit/references/project-adaptation.md
@@ -1,0 +1,339 @@
+# Project Adaptation
+
+The audit skill ships with examples drawn from a specific stack (Cloudflare Workers + React 19 + Vite + TanStack Query + better-auth + Radix UI + Jezweb's `.jez/` convention). Those examples are illustrative — the discipline is the same across stacks.
+
+This file is the adaptation guide for non-default stacks.
+
+## Path conventions — fallback chain
+
+The skill defaults to `.jez/` (Jezweb's convention) but uses a fallback chain. The audit reads existing directories first; falls back to creating one only if nothing matches.
+
+| Convention | Path | Used by |
+|------------|------|---------|
+| Jezweb | `.jez/audit-evidence/<date>/` | jezweb.com.au internal projects |
+| Common docs | `docs/audits/<date>/` | many open-source projects |
+| Project-root | `audits/<date>/` | minimal projects |
+| Hidden-folder | `.audit/<date>/` | conventional fallback if nothing else exists |
+
+Same fallback applies to:
+
+- **Personas**: `.jez/audit-personas/` → `docs/personas/` → `personas/` → `.audit/personas/`
+- **Audit config (allowlist)**: `.jez/audit-config.yml` → `audit-config.yml` → `.audit/config.yml`
+- **Audit reports**: `.jez/artifacts/ux-audit-YYYY-MM-DD.md` → `docs/audits/ux-audit-YYYY-MM-DD.md` → `audits/<date>.md`
+
+The audit reads project conventions before defaulting. If the project's CLAUDE.md says *"audit reports go in `quality-reports/`"*, use that.
+
+## URL discovery by stack
+
+Phase 1 step 3 (URL discovery) needs adaptation per stack. The skill default checks `wrangler.jsonc`, falls back to `lsof -i :5173 -i :3000 -i :8787`. Stacks below have different conventions:
+
+| Stack | Where to look | Common ports |
+|-------|---------------|--------------|
+| **Cloudflare Workers** | `wrangler.jsonc` `pattern` / `custom_domain` | 8787, 5173 (Vite dev) |
+| **Vite (any framework)** | `vite.config.ts` `server.port` | 5173 default |
+| **Next.js** | `package.json` scripts; `.env.local` `NEXT_PUBLIC_*` | 3000 default |
+| **Remix** | `vite.config.ts` or `remix.config.js` | 3000 default |
+| **Rails** | `config/database.yml`, `bin/rails server` | 3000 default |
+| **Django** | `manage.py runserver`, `settings.py` `ALLOWED_HOSTS` | 8000 default |
+| **Laravel** | `.env` `APP_URL`, `php artisan serve` | 8000 default |
+| **PHP (Apache/Nginx)** | virtualhost config; check `localhost` or `*.test` | 80, 443, 8080 |
+| **WordPress** | `wp-config.php` `WP_HOME` / `WP_SITEURL`; Local-by-Flywheel sites at `*.local` | 80, 443, custom |
+| **Symfony** | `bin/console server:start` | 8000 default |
+| **Static / Astro / Hugo** | `astro.config.mjs` / `hugo.toml`; deployment preview URL | 4321 (Astro), 1313 (Hugo) |
+
+**Discovery order regardless of stack**:
+
+1. Check the project's CLAUDE.md / README for "URL" or "dev server"
+2. Check stack-specific config file (per table above)
+3. Run `lsof -i :PORT_RANGE` or `ss -tlnp | grep LISTEN` for matching dev ports
+4. Ask the user
+
+Always prefer the deployed URL over local dev — local misses CDN, CORS, latency, real auth.
+
+## Test-auth alternatives (headless authentication)
+
+The skill's headless test-auth pattern is **better-auth-specific** (`/api/test-auth/cookies` endpoint with X-Test-Auth secret). Other auth stacks need different approaches:
+
+### better-auth (default in skill)
+```bash
+curl -sX POST "$URL/api/test-auth/cookies" \
+  -H "X-Test-Auth: $TEST_AUTH_TOKEN" \
+  -d '{"email":"alice@test.app.local"}' > cookies.json
+```
+
+### NextAuth / Auth.js
+Two patterns:
+1. **Test-only credentials provider** — register a `Credentials` provider gated on `NODE_ENV !== 'production'` that accepts a test token, returns a session for any email
+2. **Direct session injection** — write a session row to the DB with a known token, set the `next-auth.session-token` cookie in Playwright
+
+```ts
+// Playwright before-each: bypass the auth flow
+await page.context().addCookies([{
+  name: 'next-auth.session-token',
+  value: process.env.TEST_SESSION_TOKEN,
+  domain: 'localhost',
+  path: '/',
+}]);
+```
+
+### Lucia
+Use `lucia.createSession(userId, attributes)` server-side, write the session cookie manually. Wrap in a test-only `/api/test-auth` route gated on env.
+
+### Rails Devise
+Use Devise's `sign_in` helper in a test-only controller action:
+```ruby
+# Only mounted in test/dev
+class TestAuthController < ApplicationController
+  def sign_in_as
+    user = User.find_or_create_by!(email: params[:email])
+    sign_in user
+    head :ok
+  end
+end
+```
+
+### Django auth
+Test view using `force_login`:
+```python
+# urls.py — only mounted when DEBUG = True
+def test_login(request):
+    user, _ = User.objects.get_or_create(email=request.GET['email'])
+    login(request, user)
+    return HttpResponse(status=200)
+```
+
+### Custom JWT / API tokens
+Mint a test JWT with a known secret, set in `Authorization` header for Playwright:
+```ts
+await page.setExtraHTTPHeaders({ Authorization: `Bearer ${process.env.TEST_JWT}` });
+```
+
+### Magic-link bypass
+For magic-link auth (Clerk, Resend Auth, Supabase Auth): expose a test-only endpoint that mints a magic-link token and returns it, skipping email delivery.
+
+### WordPress
+Use WP-CLI or `wp_set_current_user()` / `wp_set_auth_cookie()` in a test mu-plugin gated on a constant. Or use a session-stealing test plugin.
+
+**Pattern across all stacks**: gate test-auth on a server-side environment variable (`TEST_AUTH_ENABLED=true` only in dev/staging), use a token / shared secret to authorise, lock to email patterns like `*@test.<app>.local` to prevent real-user takeover.
+
+## Seed-script architectures by ORM
+
+The data-seasoning scenario assumes the project provides Day 0 / 1 / 7 / 30 seed scripts. The skill's example uses Drizzle/D1; here's the pattern across ORMs:
+
+### Drizzle (Cloudflare D1, PostgreSQL, MySQL, SQLite)
+```
+scripts/seed/horizons/day-7.ts
+import { db } from '../../../src/db';
+import { faker } from '@faker-js/faker';
+import { inboxItems, conversations } from '../../../src/db/schema';
+
+await db.insert(inboxItems).values(
+  Array.from({ length: 75 }, () => ({...})),
+);
+```
+
+### Prisma
+```
+prisma/seeds/horizons/day-7.ts
+import { PrismaClient } from '@prisma/client';
+import { faker } from '@faker-js/faker';
+
+const prisma = new PrismaClient();
+await prisma.inboxItem.createMany({ data: [...] });
+```
+
+### TypeORM / MikroORM
+Equivalent: use the entity manager / repository, batch insert.
+
+### Sequelize
+```
+scripts/seed/day-7.js
+const { Inbox } = require('../../models');
+await Inbox.bulkCreate(items);
+```
+
+### Rails ActiveRecord
+```
+db/seeds/horizons/day_7.rb
+require 'faker'
+75.times { Inbox.create!(...) }
+```
+
+CLI: `bundle exec rails runner db/seeds/horizons/day_7.rb`
+
+### Django ORM
+```
+audit/management/commands/seed_horizon.py
+from django.core.management.base import BaseCommand
+from inbox.models import Item
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('horizon', choices=['day-0', 'day-1', 'day-7', 'day-30'])
+    def handle(self, *args, **opts):
+        # ...
+```
+
+CLI: `python manage.py seed_horizon day-7`
+
+### Laravel Eloquent
+```
+database/seeders/HorizonsSeeder.php
+class HorizonsSeeder extends Seeder { /* ... */ }
+```
+
+CLI: `php artisan db:seed --class=HorizonsSeeder`
+
+### WordPress
+Custom WP-CLI command:
+```
+wp eval-file scripts/seed-horizon.php day-7
+```
+
+### Raw SQL
+For projects without an ORM: SQL files at `scripts/seed/horizons/day-7.sql`, run via `psql -f` / `sqlite3 < file` / `wrangler d1 execute --file=`.
+
+**Pattern**: each horizon = one script that resets state and seeds horizon-appropriate data with realistic time distribution. Use a faker-equivalent for realistic content. CLI per horizon: `<runner> seed:day-N`.
+
+## Build verify by stack
+
+Phase 1 capability tests + Phase 7 fix-and-verify both need stack-aware build commands:
+
+| Stack | Type-check | Build | Run tests |
+|-------|------------|-------|-----------|
+| Node + TS | `tsc --noEmit` or `pnpm typecheck` | `pnpm build` | `pnpm test` / `pnpm vitest` |
+| Next.js | included in `next build` | `next build` | `next test` / `vitest` |
+| Cloudflare Workers | `tsc --noEmit` + Vite build | `wrangler deploy --dry-run` | `vitest` |
+| Rails | n/a (Ruby) | `bundle exec rails assets:precompile` | `bundle exec rspec` / `rails test` |
+| Django | `python manage.py check` | `collectstatic` | `pytest` / `python manage.py test` |
+| Laravel | n/a (PHP) | `php artisan optimize` | `php artisan test` |
+| WordPress | n/a | n/a | optional plugin test suite |
+| Static (Astro/Hugo) | `astro check` / n/a | `astro build` / `hugo --minify` | optional |
+| Mobile (React Native) | `tsc --noEmit` | `expo build` / native build | `jest` |
+
+Detect by reading project files: `package.json` scripts, `Gemfile`, `requirements.txt`, `composer.json`, `manage.py`, `Cargo.toml`, `go.mod`, etc.
+
+## SDK contract examples by ecosystem
+
+The `live-interaction-smoke.md` SDK contract table is heavily React + TanStack + Radix biased. Equivalents in other ecosystems:
+
+### Vue 3
+- **Pinia stores** with `$reset()` not called in cleanup → state leaks between tests
+- **vue-router** `beforeEach` guards must `next()` or navigation hangs
+- **VueQuery** — same `queryKey` stale-results pattern as TanStack Query (it's a port)
+- **Headless UI** — same Dialog focus-trap requirements as Radix
+
+### Svelte / SvelteKit
+- **Stores** without `derived` for computed state → re-render storms
+- **Actions** that don't return `{ destroy }` → leaks
+- **`+page.server.ts`** without proper `redirect()` semantics
+
+### Angular
+- **RxJS subscriptions** without `takeUntil(destroy$)` → memory leaks
+- **Angular Material `<mat-dialog>`** — focus-trap vs Esc-key handling
+- **Forms reactive vs template-driven mix** — silent validation loss
+
+### Native browser / vanilla JS
+- **Form validation** without `novalidate` → browser default messages override custom
+- **`<dialog>` element** without `showModal()` — backdrop missing
+
+### WordPress / PHP
+- **Nonce checks** missing on AJAX endpoints → CSRF + silent failure
+- **`wp_die()` vs `wp_send_json_error()`** — wrong error response shape breaks JS handlers
+- **Block editor (Gutenberg)** — `useBlockProps()` not spread → missing styling
+
+### iOS / SwiftUI (mobile)
+- **`@Published` not on main actor** → UI updates from background thread
+- **Sheets without `.presentationDetents`** → broken sizing on iOS 16+
+- **List with `.id()`** missing — animations break
+
+The general principle: any ecosystem has a class of "undocumented option that silently breaks behaviour if missing". The audit catches them by clicking + watching network + watching DOM. The catalogue in `live-interaction-smoke.md` is the React/TanStack flavour — read your stack's docs for the same shape.
+
+## Reference apps by category
+
+For visual-polish calibration, the skill defaults to Linear / Stripe / Vercel / Notion (B2B SaaS / dev-tooling). Different app categories want different references:
+
+| Category | Reference apps |
+|----------|---------------|
+| **B2B SaaS / dev tools** | Linear, Stripe, Vercel Dashboard, Notion, Cron, Raycast |
+| **B2C consumer** | Airbnb, Notion (consumer plan), Things 3, Dropbox |
+| **E-commerce** | Stripe Checkout, Shopify storefront examples, Apple Store, Amazon |
+| **CMS / content** | Ghost editor, Sanity Studio, Contentful, Webflow |
+| **Mobile-first** | Cron mobile, Notion Calendar, Linear mobile, Things 3 |
+| **Marketing / landing** | Stripe.com, Linear.app, Vercel.com, Apple product pages |
+| **Editor / creative** | Figma, Canva, Linear's editor, Notion |
+| **Email / messaging** | Superhuman, Hey, claude.ai, ChatGPT |
+| **Internal admin / dashboard** | Stripe Dashboard, Vercel Dashboard, Cloudflare Dashboard, AWS Console (as anti-example) |
+| **Public sector / accessibility-first** | gov.uk, healthcare.gov (post-redesign) |
+| **News / publishing** | NYT, Stratechery, FT.com |
+| **WordPress sites** | a polished agency reference site, the project's reference site, a competitor |
+
+Pick 3 references per audit *from the right category*. Cross-category references confuse the calibration ("Linear is good and we're not Linear" is true but unhelpful for an e-commerce checkout).
+
+## Persona library by app type
+
+The default personas in `persona-lock.md` (SME owner, power user, first-time developer) are biased to B2B SaaS. Different app types want different personas:
+
+### Consumer apps
+- Curious newcomer (came via marketing, no commitment)
+- Returning casual (uses 2-3 features)
+- Devoted power user (knows every shortcut)
+
+### E-commerce
+- Browsing visitor (no intent to buy)
+- Comparison shopper (multiple tabs open)
+- Repeat buyer (knows the product)
+- Gift purchaser (buying for someone else)
+
+### CMS / publishing
+- Writer (focuses on content)
+- Editor (focuses on flow + queue)
+- Designer (focuses on layout)
+- Reader (the published audience)
+
+### Internal admin tools
+- Operator (does the daily work)
+- Manager (reviews + approves)
+- Auditor (compliance / external review)
+- New hire (onboarding into the tool)
+
+### Mobile-first
+- One-thumb commuter
+- At-the-desk multitasker
+- Quick check between meetings
+
+### WordPress / agency
+- Site owner (non-technical, manages content)
+- Content editor (writes posts, uploads media)
+- Developer (PHP/theme work)
+- Visitor (the published site's audience)
+
+Each persona file follows the same format as `persona-lock.md` — Goals / Constraints / Pain triggers / Wins / How to audit AS them.
+
+## When the project is brand-new (no prior conventions)
+
+If the project has none of the above conventions established (no audit folder, no personas, no test-auth, no seed scripts), the audit's first run is partly *bootstrapping*:
+
+1. **Pick a fallback path** for audit artefacts (`.audit/<date>/` is the safest hidden default)
+2. **Ask + write a persona file** — capture in `.audit/personas/<slug>.md` for next time
+3. **Note in the report** that the project lacks test-auth / seed scripts; recommend adopting them
+4. **Verdict can still be Pass / Conditional Pass** — bootstrap-state isn't an audit failure
+5. **First audit takes longer** than subsequent ones because it's establishing the conventions
+
+Subsequent audits inherit the conventions and run faster.
+
+## What stays universal
+
+The discipline above all this:
+
+- **Interaction-first methodology** — works on any UI, any stack, any framework
+- **Hard gates** (console errors / warnings, network errors, layout collapse) — every web stack has these
+- **Persona Lock + first-time-user lens** — always applies
+- **Multi-pane stress matrix** — applies to any app with collapsible UI
+- **Visual polish + AI-tells** — stack-agnostic; pattern recognition on rendered pixels
+- **Component perfection checklist** (6 categories + 6 states) — categories are universal
+- **Scenario battery** — all 11 scenarios apply to any web app (skip Data Seasoning if no time-distributed data)
+- **Audit-the-audit meta-check** — universal
+- **Top 5 + self-critique + smallest-patch + hold-this discipline** — universal
+
+The skill's core is stack-agnostic. The examples in references illustrate one stack — this file shows how to translate them.

--- a/plugins/dev-tools/skills/ux-audit/references/visual-polish.md
+++ b/plugins/dev-tools/skills/ux-audit/references/visual-polish.md
@@ -183,7 +183,7 @@ Polished apps often break symmetry intentionally:
 **How to check**: hide content for a moment and look at structural composition.
 - Does the page feel composed, or laid out by a templater?
 - Is white space trapped (awkward) or shaped (intentional)?
-- Compare to reference apps: Linear (asymmetric editorial), Stripe Dashboard (deliberate hierarchy), Notion (intentional density), Vercel Dashboard (informational density with whitespace).
+- Compare to reference apps **in the same category**: Linear (asymmetric editorial), Stripe Dashboard (deliberate hierarchy), Notion (intentional density), Vercel Dashboard (informational density with whitespace). Different category = different references; see [project-adaptation.md](project-adaptation.md) "Reference apps by category" for B2C / e-commerce / CMS / mobile / WordPress equivalents.
 
 **Findings shape**: *"Settings page form is centred in 768px container. Other pages use a left-aligned 640px column with right rail for help/docs. Centred form on settings reads as orphaned and template-generated."*
 


### PR DESCRIPTION
Makes the skill adaptable across project types. Public skill (661+ stars) was previously coupled to Cloudflare Workers + React + Vite + TanStack + better-auth + Radix + Jezweb `.jez/` convention.

# What's new

`references/project-adaptation.md` (339 lines) — single doc covering:

| Section | Coverage |
|---------|----------|
| Path conventions | `.jez/` → `docs/audits/` → `audits/` → `.audit/` fallback chain |
| URL discovery | Cloudflare, Vite, Next.js, Remix, Rails, Django, Laravel, PHP, WordPress, Symfony, Astro, Hugo |
| Test-auth alternatives | better-auth (default), NextAuth/Auth.js, Lucia, Rails Devise, Django auth, custom JWT, magic-link, WordPress |
| Seed-script architectures | Drizzle, Prisma, TypeORM, Sequelize, ActiveRecord, Django ORM, Laravel Eloquent, WordPress, raw SQL |
| Build verify by stack | Node+TS, Next.js, Workers, Rails, Django, Laravel, WordPress, static, mobile |
| SDK contract examples | React/TanStack/Radix (default), Vue 3, Svelte, Angular, vanilla, WordPress/PHP, iOS/SwiftUI |
| Reference apps by category | B2B SaaS / B2C / e-commerce / CMS / mobile-first / marketing / editor / messaging / admin / public sector / WordPress |
| Persona library by app type | consumer, e-commerce, CMS, internal admin, mobile-first, WordPress/agency |
| Bootstrap protocol | for brand-new projects with no prior conventions |

# Targeted edits

Existing references reframe stack-specific content as examples rather than defaults:

- SKILL.md Phase 1.3 — URL discovery is a stack-detection table
- SKILL.md path mentions — fallback chains documented
- live-interaction-smoke.md — SDK contract table noted as React/TanStack flavour
- audit-config.md — file location fallback chain extended
- data-seasoning.md — seed-script noted as Drizzle example
- persona-lock.md — examples noted as B2B-SaaS bias
- visual-polish.md — reference apps noted as 'same category' rule
- browser-tools.md — test-auth noted as better-auth example

Each existing reference now points at `project-adaptation.md` for the equivalents in other stacks.

# What stays universal

The discipline above all this is stack-agnostic:

- Interaction-first methodology
- Hard gates (console / network / layout)
- Persona Lock + first-time-user lens
- Multi-pane stress matrix
- Visual polish + AI-tells
- Component perfection checklist
- 11-scenario battery
- Audit-the-audit meta-check
- Output discipline (Top 5 / self-critique / smallest-patch / hold-this)

The skill's *core* never assumed a specific stack. The examples in references illustrated one stack — this PR makes that explicit.

# Validation

- bin/skill-lint passes (494 lines, under 500-line cap)
- 22 reference files in place
- All trigger phrases preserved
- Path fallback chains tested by reading existing reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)