### PR TITLE
fix(codex-review): drop the piped prompt from scoped invocations

### DIFF
--- a/plugins/dev-tools/skills/codex-review/SKILL.md
+++ b/plugins/dev-tools/skills/codex-review/SKILL.md
@@ -59,21 +59,30 @@ OUT=".jez/reviews/codex-${TS}.md"
 SKILL_DIR="$(dirname "$0")"  # or use the skill's absolute path
 
 # Example: uncommitted changes
-cat "${SKILL_DIR}/prompt.md" | codex review --uncommitted - 2>&1 | tee "$OUT"
+codex review --uncommitted 2>&1 | tee "$OUT"
 ```
 
 Other scopes:
 
 ```bash
 # Vs base branch
-cat prompt.md | codex review --base main - 2>&1 | tee "$OUT"
+codex review --base main 2>&1 | tee "$OUT"
 
 # Specific commit
-cat prompt.md | codex review --commit abc123 - 2>&1 | tee "$OUT"
+codex review --commit abc123 2>&1 | tee "$OUT"
 
-# Current HEAD (no scope flag)
-cat prompt.md | codex review - 2>&1 | tee "$OUT"
+# Current HEAD, with the custom prompt (the only form that accepts one)
+cat "${SKILL_DIR}/prompt.md" | codex review - 2>&1 | tee "$OUT"
 ```
+
+**A scope flag and a prompt are mutually exclusive.** On codex-cli 0.149.1,
+`codex review --base main -` fails with
+`error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'`; the same applies
+to `--uncommitted` and `--commit`. Only the unscoped form accepts `prompt.md`.
+
+This is not much of a loss, and arguably a gain — see the note under Rules about keeping
+the review neutral. `--title "<label>"` names the run in the review summary and works with
+any scope.
 
 `codex review` can take several minutes on a large diff. Let it run.
 


### PR DESCRIPTION
Fixes #100

## What was wrong

codex-cli 0.149.1 made a scope flag and a `[PROMPT]` argument mutually exclusive, so all
three scoped invocations this skill documented now fail outright:

```
$ echo "focus on X" | codex review --base main -
error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'
```

I probed every form:

| Invocation | 0.149.1 |
| --- | --- |
| `codex review --uncommitted <PROMPT>` | rejected |
| `codex review --base main <PROMPT>` | rejected |
| `codex review --commit <sha> <PROMPT>` | rejected |
| `codex review <PROMPT>` (no scope flag) | works |

Three of the skill's four documented modes were unusable, and the surviving one —
whole-app review at HEAD — is the least likely to be what someone wants.

## What changed

The scoped examples drop the pipe. The `prompt.md` example moves to the unscoped form,
which is the only one that still accepts it. The constraint is stated inline so the next
reader learns it here rather than from a usage error mid-task, and `--title` is mentioned,
which the skill did not previously cover.

Docs only — no behaviour or tooling changes.

## A note on the tradeoff

Losing the custom prompt on scoped reviews reads like a downgrade, but this skill's own
Rules section already argues the other way:

> Don't leak Claude's reasoning into the prompt. The `prompt.md` file is deliberately
> neutral — Codex reviews the code, not Claude's narrative about the code. Independence is
> the whole point.

A review steered by the model whose work is under review is less independent, not more. If
project-specific review guidance genuinely needs to persist, `AGENTS.md` in the repo is a
scope-compatible route — Codex reads it on every run, though it applies to all `codex`
invocations there, not just reviews. I left that out of the skill body as a judgment call;
happy to add it if you'd rather it were documented.

## Verification

Ran `codex review --base main` against a real repository on 0.149.1 with the corrected
form: it completed and produced a report. The rejections above are the actual CLI output,
not inferred from `--help`.
